### PR TITLE
feat: 회원가입 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,9 @@ dependencies {
     // 아래 두 줄은 일부 환경에서 APT가 Jakarta 어노테이션을 못 찾는 문제 예방용 (선택적이지만 권장)
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+    // 인증·인가(Security) 기능
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/musinssak/MusinssakApplication.java
+++ b/src/main/java/com/example/musinssak/MusinssakApplication.java
@@ -2,7 +2,9 @@ package com.example.musinssak;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class MusinssakApplication {
 

--- a/src/main/java/com/example/musinssak/api/auth/AuthController.java
+++ b/src/main/java/com/example/musinssak/api/auth/AuthController.java
@@ -1,0 +1,27 @@
+package com.example.musinssak.api.auth;
+
+import com.example.musinssak.api.auth.dto.RegisterRequest;
+import com.example.musinssak.common.web.ApiResponse;
+import com.example.musinssak.domain.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService; // 서비스는 다음 단계에서 구현
+
+    /**
+     * 회원가입
+     * POST /api/auth/register
+     * @param request 회원가입 요청 데이터 (이메일, 비밀번호, 닉네임)
+     * @return 회원가입 성공 응답
+     */
+    @PostMapping("/register")
+    public ApiResponse<Void> register(@RequestBody RegisterRequest request) {
+        authService.register(request);
+        return ApiResponse.success("회원가입이 완료되었습니다.");
+    }
+}

--- a/src/main/java/com/example/musinssak/api/auth/dto/RegisterRequest.java
+++ b/src/main/java/com/example/musinssak/api/auth/dto/RegisterRequest.java
@@ -1,0 +1,14 @@
+package com.example.musinssak.api.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor
+public class RegisterRequest {
+    private String email;
+    private String password;
+    private String nickname;
+}

--- a/src/main/java/com/example/musinssak/api/product/ProductController.java
+++ b/src/main/java/com/example/musinssak/api/product/ProductController.java
@@ -4,6 +4,7 @@ import com.example.musinssak.api.product.dto.ProductListRequest;
 import com.example.musinssak.api.product.dto.ProductMainResponse;
 import com.example.musinssak.api.product.dto.ProductSearchRequest;
 import com.example.musinssak.api.product.dto.ProductSearchResultResponse;
+import com.example.musinssak.common.web.ApiResponse;
 import com.example.musinssak.domain.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -27,16 +28,14 @@ public class ProductController {
      * 메인 화면 최신 상품 목록 10개
      */
     @GetMapping("/main")
-    public ResponseEntity<Map<String, Object>> getMainProducts() {
+    public ResponseEntity<ApiResponse<Map<String, Object>>> getMainProducts() {
         List<ProductMainResponse> products = productService.getMainProducts();
 
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", 200);
-        response.put("code", "SUCCESS");
-        response.put("message", "신규 상품 목록이 성공적으로 조회되었습니다.");
-        response.put("data", Map.of("products", products));
-
-        return ResponseEntity.ok(response);
+        // data 구조는 기존 명세서대로 "products" 키를 유지
+        Map<String, Object> data = Map.of("products", products);
+        return ResponseEntity.ok(
+                ApiResponse.success("신규 상품 목록이 성공적으로 조회되었습니다.", data)
+        );
     }
 
     /**
@@ -44,31 +43,22 @@ public class ProductController {
      * 프론트 : brand=A&brand=B 가정
      */
     @GetMapping("/search")
-    public ResponseEntity<Map<String, Object>> searchProducts(@ModelAttribute ProductSearchRequest request) {
+    public ResponseEntity<ApiResponse<ProductSearchResultResponse>> searchProducts(@ModelAttribute ProductSearchRequest request) {
         // 상품 목록 + 커서 포함된 응답
-        ProductSearchResultResponse response = productService.searchProducts(request);
-
-        Map<String, Object> result = new HashMap<>();
-        result.put("status", 200);
-        result.put("code", "SUCCESS");
-        result.put("message", "상품 검색 결과가 성공적으로 조회되었습니다.");
-        result.put("data", response); // 전체 응답 구조를 담은 객체
-
-        return ResponseEntity.ok(result);
+        ProductSearchResultResponse data = productService.searchProducts(request);
+        return ResponseEntity.ok(
+                ApiResponse.success("상품 검색 결과가 성공적으로 조회되었습니다.", data)
+        );
     }
 
     /**
      * 카테고리 페이지 (검색 x)
      */
     @GetMapping
-    public ResponseEntity<Map<String, Object>> listByCategory(@ModelAttribute ProductListRequest request) {
-        ProductSearchResultResponse response = productService.listProducts(request);
-
-        Map<String, Object> result = new HashMap<>();
-        result.put("status", 200);
-        result.put("code", "SUCCESS");
-        result.put("message", "상품 목록이 성공적으로 조회되었습니다.");
-        result.put("data", response);
-        return ResponseEntity.ok(result);
+    public ResponseEntity<ApiResponse<ProductSearchResultResponse>> listByCategory(@ModelAttribute ProductListRequest request) {
+        ProductSearchResultResponse data = productService.listProducts(request);
+        return ResponseEntity.ok(
+                ApiResponse.success("상품 목록이 성공적으로 조회되었습니다.", data)
+        );
     }
 }

--- a/src/main/java/com/example/musinssak/common/exception/BusinessException.java
+++ b/src/main/java/com/example/musinssak/common/exception/BusinessException.java
@@ -1,0 +1,13 @@
+package com.example.musinssak.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/example/musinssak/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/musinssak/common/exception/ErrorCode.java
@@ -1,0 +1,22 @@
+package com.example.musinssak.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+    EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "EMAIL_DUPLICATED", "이미 사용 중인 이메일입니다."),
+    NICKNAME_DUPLICATED(HttpStatus.BAD_REQUEST, "NICKNAME_DUPLICATED", "이미 사용 중인 닉네임입니다."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "요청 형식이 잘못되었습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/musinssak/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/musinssak/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,34 @@
+package com.example.musinssak.common.exception;
+
+import com.example.musinssak.common.web.ApiResponse;
+import jakarta.validation.ConstraintViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ApiResponse<Void>> handleBusiness(BusinessException ex) {
+        var ec = ex.getErrorCode();
+        return ResponseEntity.status(ec.getHttpStatus())
+                .body(ApiResponse.error(ec.getHttpStatus().value(), ec.getCode(), ec.getMessage()));
+    }
+
+    // (선택) 바디 검증 실패 등 형식 오류
+    @ExceptionHandler({MethodArgumentNotValidException.class, ConstraintViolationException.class, IllegalArgumentException.class})
+    public ResponseEntity<ApiResponse<Void>> handleInvalid(Exception ex) {
+        var ec = ErrorCode.INVALID_REQUEST;
+        return ResponseEntity.status(ec.getHttpStatus())
+                .body(ApiResponse.error(ec.getHttpStatus().value(), ec.getCode(), ec.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleUnknown(Exception ex) {
+        var ec = ErrorCode.INTERNAL_SERVER_ERROR;
+        return ResponseEntity.status(ec.getHttpStatus())
+                .body(ApiResponse.error(ec.getHttpStatus().value(), ec.getCode(), ec.getMessage()));
+    }
+}

--- a/src/main/java/com/example/musinssak/common/web/ApiResponse.java
+++ b/src/main/java/com/example/musinssak/common/web/ApiResponse.java
@@ -1,0 +1,38 @@
+package com.example.musinssak.common.web;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 공통 API 응답 포맷
+ * - status: HTTP 상태 코드(숫자)
+ * - code: 비즈니스 코드("SUCCESS" 또는 에러 코드)
+ * - data: 실제 응답 데이터(없으면 null)
+ * - message: 선택(성공/에러 메시지)
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ApiResponse<T> {
+    private int status;
+    private String code;
+    private T data;
+    private String message; // 선택 필드 (null 가능)
+
+    // ---------- 성공 ----------
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(200, "SUCCESS", data, null);
+    }
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(200, "SUCCESS", data, message);
+    }
+    public static ApiResponse<Void> success(String message) {
+        return new ApiResponse<>(200, "SUCCESS", null, message);
+    }
+
+    // ---------- 실패 ----------
+    public static ApiResponse<Void> error(int status, String code, String message) {
+        return new ApiResponse<>(status, code, null, message);
+    }
+}

--- a/src/main/java/com/example/musinssak/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/musinssak/domain/auth/service/AuthService.java
@@ -1,0 +1,7 @@
+package com.example.musinssak.domain.auth.service;
+
+import com.example.musinssak.api.auth.dto.RegisterRequest;
+
+public interface AuthService {
+    void register(RegisterRequest request);
+}

--- a/src/main/java/com/example/musinssak/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/example/musinssak/domain/auth/service/AuthServiceImpl.java
@@ -1,0 +1,36 @@
+package com.example.musinssak.domain.auth.service;
+
+import com.example.musinssak.api.auth.dto.RegisterRequest;
+import com.example.musinssak.common.exception.BusinessException;
+import com.example.musinssak.common.exception.ErrorCode;
+import com.example.musinssak.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final UserService userService; // user 도메인 서비스 주입
+    private final PasswordEncoder passwordEncoder; // 인프라
+
+    @Override
+    @Transactional
+    public void register(RegisterRequest request) {
+        // 1) 이메일/닉네임 중복 검사
+        if (userService.emailExists(request.getEmail())) {
+            throw new BusinessException(ErrorCode.EMAIL_DUPLICATED);
+        }
+        if (userService.nicknameExists(request.getNickname())) {
+            throw new BusinessException(ErrorCode.NICKNAME_DUPLICATED);
+        }
+
+        // 2) 패스워드는 해시로 저장 (BCrypt)
+        String hash = passwordEncoder.encode(request.getPassword());
+
+        // 3) 저장
+        userService.createUser(request.getEmail(), hash, request.getNickname());
+    }
+}

--- a/src/main/java/com/example/musinssak/domain/user/entity/User.java
+++ b/src/main/java/com/example/musinssak/domain/user/entity/User.java
@@ -1,0 +1,57 @@
+package com.example.musinssak.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 255)
+    private String email;
+
+    // DB 컬럼명은 password → 의미 명확히 하려고 필드명은 passwordHash
+    @Column(name = "password", nullable = false, length = 255)
+    private String passwordHash;
+
+    // 정책상 필수면 nullable=false, 선택이면 true로 바꾸세요
+    @Column(nullable = false, length = 100)
+    private String nickname;
+
+    @Column(length = 50)
+    private String phone;
+
+    private LocalDate birthDate;
+
+    @Column(length = 255, name = "profile_image_url")
+    private String profileImageUrl;
+
+    @Column(name = "last_password_modified_at")
+    private LocalDateTime lastPasswordModifiedAt;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;     // DB에서 기본값 주는 중이면 그대로 매핑만
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    private User(String email, String passwordHash, String nickname) {
+        this.email = email;
+        this.passwordHash = passwordHash;
+        this.nickname = nickname;
+    }
+
+    public static User create(String email, String passwordHash, String nickname) {
+        return new User(email, passwordHash, nickname);
+    }
+}

--- a/src/main/java/com/example/musinssak/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/musinssak/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.example.musinssak.domain.user.repository;
+
+import com.example.musinssak.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+    boolean existsByNickname(String nickname);
+    Optional<User> findByEmail(String email); // 로그인에서 사용할 예정
+}

--- a/src/main/java/com/example/musinssak/domain/user/service/UserService.java
+++ b/src/main/java/com/example/musinssak/domain/user/service/UserService.java
@@ -1,0 +1,9 @@
+package com.example.musinssak.domain.user.service;
+
+import com.example.musinssak.domain.user.entity.User;
+
+public interface UserService {
+    boolean emailExists(String email);
+    boolean nicknameExists(String nickname);
+    User createUser(String email, String passwordHash, String nickname);
+}

--- a/src/main/java/com/example/musinssak/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/musinssak/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,31 @@
+package com.example.musinssak.domain.user.service;
+
+import com.example.musinssak.domain.user.entity.User;
+import com.example.musinssak.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean emailExists(String email) {
+        return userRepository.existsByEmail(email);
+    }
+
+    @Override
+    public boolean nicknameExists(String nickname) {
+        return userRepository.existsByNickname(nickname);
+    }
+
+    @Override
+    @Transactional
+    public User createUser(String email, String passwordHash, String nickname) {
+        return userRepository.save(User.create(email, passwordHash, nickname));
+    }
+}

--- a/src/main/java/com/example/musinssak/infra/security/SecurityConfig.java
+++ b/src/main/java/com/example/musinssak/infra/security/SecurityConfig.java
@@ -1,0 +1,39 @@
+package com.example.musinssak.infra.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * 인증·인가(Security) 관련 설정 클래스
+ */
+@Configuration
+public class SecurityConfig {
+
+    // BCrypt 해시 (회원가입/로그인에서 사용)
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    // 개발 단계: 인증 잠금 해제(permitAll). JWT 필터 붙인 뒤 보호 범위 조정 예정.
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/api/auth/**",
+                                "/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html"
+                        ).permitAll()
+                        .anyRequest().permitAll()   // ← 개발용. JWT 붙인 다음 authenticated()로 바꾸면 됨
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/resources/db/migration/V5__users_add_unique_constraints.sql
+++ b/src/main/resources/db/migration/V5__users_add_unique_constraints.sql
@@ -1,0 +1,13 @@
+-- V5__users_add_unique_constraints.sql
+-- 목적: 이메일/닉네임 컬럼에 UNIQUE 제약을 추가하여 DB 차원 중복 방지
+-- 주의:
+--  1) 현재 테이블에 중복 데이터가 존재하면 이 마이그레이션은 실패합니다.
+--     적용 전, 중복 여부를 점검하세요.
+--       예) SELECT email, COUNT(*) c FROM users GROUP BY email HAVING c > 1;
+--           SELECT nickname, COUNT(*) c FROM users GROUP BY nickname HAVING c > 1;
+--  2) MySQL의 UNIQUE는 NULL을 여러 개 허용합니다.
+--     닉네임을 반드시 고유하게 강제하려면 이후 단계에서 NOT NULL도 함께 적용할 예정입니다.
+
+ALTER TABLE users
+    ADD CONSTRAINT uk_users_email UNIQUE (email),
+    ADD CONSTRAINT uk_users_nickname UNIQUE (nickname);


### PR DESCRIPTION
[작업한 내용]

- 회원가입 API 컨트롤러, 서비스, DTO 구현
- User 도메인(Entity, Repository, Service) 생성
- 이메일/닉네임 중복 검사 로직 추가
- 공통 응답/에러 처리 적용
- users 테이블 이메일·닉네임 unique 제약조건 추가
- SecurityConfig에 PasswordEncoder 설정

[참고사항]
- 로그인 + JWT 토큰 발급 로직은 이후 단계에서 구현 예정