### PR TITLE
feat(mypage): 프로필/비밀번호/배송지 CRUD + 기본배송지 설정 & 카카오 주소검색 연동

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -63,3 +63,9 @@ jwt:
   secret: ${JWT_SECRET} # 여기에 매우 길고 복잡한 랜덤 시크릿 값을 넣으세요_예:5xZrJc... (Base64 가능)
   access-expire-ms: ${JWT_ACCESS_EXPIRE_MS}     # 기본 15분
   refresh-expire-ms: ${JWT_REFRESH_EXPIRE_MS}  # 기본 14일
+
+# 주소검색 API 설정
+kakao:
+  local:
+    base-url: https://dapi.kakao.com  # 카카오 주소검색 API 기본 URL
+    rest-api-key: ${KAKAO_REST_API_KEY}  # .env에서 REST API 키를 불러옴

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     // implementation 'org.flywaydb:flyway-core:9.22.3' // 또는 최신 버전
 
 
-    // --- QueryDSL (Spring Boot 3.x / Jakarta) ---
+    // QueryDSL (Spring Boot 3.x / Jakarta)
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'      // JPA 메타모델 참조용 (컴파일/런타임)
     annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta' // Q클래스 생성기(Annotation Processor)
     // 아래 두 줄은 일부 환경에서 APT가 Jakarta 어노테이션을 못 찾는 문제 예방용 (선택적이지만 권장)
@@ -70,10 +70,13 @@ dependencies {
     // 인증·인가(Security) 기능
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
-    // --- JJWT (토큰 생성/검증) ---
+    // JJWT (토큰 생성/검증)
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly   'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly   'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // 주소검색 JDK 9 이상에서 PostConstruct 사용을 위해
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/musinssak/api/address/AddressSearchController.java
+++ b/src/main/java/com/example/musinssak/api/address/AddressSearchController.java
@@ -1,0 +1,27 @@
+package com.example.musinssak.api.address;
+
+import com.example.musinssak.api.user.dto.AddressSearchResponse;
+import com.example.musinssak.domain.user.service.AddressSearchService;
+import com.example.musinssak.common.web.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/address")
+@RequiredArgsConstructor
+public class AddressSearchController {
+
+    private final AddressSearchService addressSearchService;
+
+    /**
+     * 주소 검색
+     * GET /api/address/search?query=서울 강남구
+     */
+    @GetMapping("/search")
+    public ApiResponse<AddressSearchResponse> search(@RequestParam String query) {
+        var data = addressSearchService.search(query);
+        return ApiResponse.success("주소 검색이 완료되었습니다.", data);
+    }
+}

--- a/src/main/java/com/example/musinssak/api/auth/AuthController.java
+++ b/src/main/java/com/example/musinssak/api/auth/AuthController.java
@@ -47,6 +47,7 @@ public class AuthController {
         // LoginResponse tokens = authService.login(request);
         var body = authService.login(request); // userId, accessToken 채워서 반환
         String userId = body.getUserId();
+        log.info("userId={}", userId);
 
         String refresh = jwtTokenProvider.createRefreshToken(userId);
         // String refresh = jwtTokenProvider.generateRefreshToken(userId); // 동일한 의미

--- a/src/main/java/com/example/musinssak/api/auth/LogoutController.java
+++ b/src/main/java/com/example/musinssak/api/auth/LogoutController.java
@@ -1,4 +1,4 @@
-package com.example.musinssak.api.auth.dto;
+package com.example.musinssak.api.auth;
 
 import com.example.musinssak.common.web.ApiResponse;
 import com.example.musinssak.infra.security.JwtTokenProvider;

--- a/src/main/java/com/example/musinssak/api/user/AddressController.java
+++ b/src/main/java/com/example/musinssak/api/user/AddressController.java
@@ -1,0 +1,132 @@
+package com.example.musinssak.api.user;
+
+import com.example.musinssak.api.user.dto.AddressResponse;
+import com.example.musinssak.api.user.dto.CreateAddressRequest;
+import com.example.musinssak.api.user.dto.DefaultAddressUpdateResponse;
+import com.example.musinssak.api.user.dto.UpdateAddressRequest;
+import com.example.musinssak.common.web.ApiResponse;
+import com.example.musinssak.domain.user.service.AddressService;
+import com.example.musinssak.infra.security.JwtTokenProvider;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class AddressController {
+
+    private final AddressService addressService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 배송지 목록 조회
+     * GET /api/users/me/addresses
+     * @param authorizationHeader
+     * @return 로그인 사용자의 배송지 목록, 없으면 data: []
+     */
+    @GetMapping("/me/addresses")
+    public ApiResponse<List<AddressResponse>> getMyAddresses(
+            @RequestHeader("Authorization") String authorizationHeader
+    ) {
+        String token = authorizationHeader.replace("Bearer ", "").trim();
+        Long userId = Long.parseLong(jwtTokenProvider.getSubject(token));
+
+        List<AddressResponse> data = addressService.getMyAddresses(userId);
+        return ApiResponse.success("배송지 목록이 성공적으로 조회되었습니다.", data);
+    }
+
+    /**
+     * 기본 배송지 설정
+     * PUT /api/users/me/addresses/{addressId}/default
+     * @param authorizationHeader
+     * @param addressId
+     * @return
+     */
+    @PutMapping("/me/addresses/{addressId}/default")
+    public ApiResponse<DefaultAddressUpdateResponse> setDefaultAddress(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @PathVariable Long addressId
+    ) {
+        String token = authorizationHeader.replace("Bearer ", "").trim();
+        Long userId = Long.parseLong(jwtTokenProvider.getSubject(token));
+
+        DefaultAddressUpdateResponse data = addressService.setDefaultAddress(userId, addressId);
+        return ApiResponse.success("기본 배송지가 성공적으로 설정되었습니다.", data);
+    }
+
+    /**
+     * 배송지 추가
+     * POST /api/users/me/addresses
+     * - isDefault=true면 기존 기본 해제 후 신규를 기본으로 설정
+     * - 첫 배송지는 자동 기본
+     * - 사용자당 최대 5개 제한
+     * @param authorizationHeader Authorization: Bearer {accessToken}
+     * @param request 배송지 생성 요청 본문
+     * @return 201 CREATED + SUCCESS + 메시지 (목록은 프론트에서 재조회)
+     */
+    @PostMapping("/me/addresses")
+    public ResponseEntity<ApiResponse<Void>> createAddress(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @Valid @RequestBody CreateAddressRequest request
+    ) {
+        String token = authorizationHeader.replace("Bearer ", "").trim();
+        Long userId = Long.parseLong(jwtTokenProvider.getSubject(token));
+
+        addressService.createAddress(userId, request);
+
+        return ResponseEntity.status(201)
+                .body(ApiResponse.created("배송지가 성공적으로 등록되었습니다."));
+    }
+
+    /**
+     * 배송지 수정
+     * PUT /api/users/me/addresses/{addressId}
+     * @param authorizationHeader
+     * @param addressId
+     * @param request
+     * @return 목록은 프론트에서 재조회
+     */
+    @PutMapping("/me/addresses/{addressId}")
+    public ApiResponse<Void> updateAddress(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @PathVariable Long addressId,
+            @Valid @RequestBody UpdateAddressRequest request
+    ) {
+        String token = authorizationHeader.replace("Bearer ", "").trim();
+        Long userId = Long.parseLong(jwtTokenProvider.getSubject(token));
+
+        addressService.updateAddress(userId, addressId, request);
+        return ApiResponse.success("배송지가 성공적으로 수정되었습니다.");
+    }
+
+    /**
+     * 배송지 삭제
+     * DELETE /api/users/me/addresses/{addressId}
+     * - 권한 체크: 내 주소만 삭제 가능 (아니면 403)
+     * - 삭제 후 정책:
+     *   (1) 삭제 전 총 개수가 2였으면 → 1개만 남으므로 남은 주소를 "자동 기본"으로 설정
+     *   (2) 그 외(삭제 후 2개 이상 또는 0개)가 되면 → 기본 배송지 없을 수도 있음(허용)
+     * - 성공 시: 200 + SUCCESS + 메시지 (목록은 프론트에서 재조회)
+     * @param authorizationHeader
+     * @param addressId
+     * @return 목록은 프론트에서 재조회
+     */
+    @DeleteMapping("/me/addresses/{addressId}")
+    public ApiResponse<Void> deleteAddress(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @PathVariable Long addressId
+    ) {
+        String token = authorizationHeader.replace("Bearer ", "").trim();
+        Long userId = Long.parseLong(jwtTokenProvider.getSubject(token));
+
+        addressService.deleteAddress(userId, addressId);
+        return ApiResponse.success("배송지가 성공적으로 삭제되었습니다.");
+    }
+
+}

--- a/src/main/java/com/example/musinssak/api/user/ProfileController.java
+++ b/src/main/java/com/example/musinssak/api/user/ProfileController.java
@@ -1,0 +1,90 @@
+package com.example.musinssak.api.user;
+
+import com.example.musinssak.api.user.dto.UpdatePasswordRequest;
+import com.example.musinssak.api.user.dto.UpdateUserProfileRequest;
+import com.example.musinssak.api.user.dto.UserProfileResponse;
+import com.example.musinssak.common.web.ApiResponse;
+import com.example.musinssak.domain.user.entity.User;
+import com.example.musinssak.domain.user.service.UserService;
+import com.example.musinssak.infra.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class ProfileController {
+
+    private final UserService userService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 프로필 조회
+     * GET /api/users/me/profile
+     * @param authorizationHeader
+     * @return 프로필 정보 반환
+     */
+    @GetMapping("/me/profile")
+    public ApiResponse<UserProfileResponse> getMyProfile(
+            @RequestHeader("Authorization") String authorizationHeader) {
+        // 1) Authorization: Bearer <token> 에서 토큰만 추출
+        String token = authorizationHeader.replace("Bearer ", "").trim();
+        // 2) 토큰에서 userId(subject) 추출
+        String userId = jwtTokenProvider.getSubject(token);
+
+        // 3) 사용자 조회
+        User user = userService.getUserById(Long.parseLong(userId));
+
+        // 4) 응답 DTO로 변환해 반환
+        return ApiResponse.success("프로필 정보가 성공적으로 조회되었습니다.",
+                new UserProfileResponse(user));
+    }
+
+    /**
+     * 프로필 수정(이름, 휴대폰, 생년월일, 프로필 이미지)
+     * PUT /api/users/me/profile
+     *
+     * - 이메일은 수정 불가
+     * - 일부 값만 보내도 됨(null은 "변경 안 함"으로 처리)
+     */
+    @PutMapping("/me/profile")
+    public ApiResponse<UserProfileResponse> updateMyProfile(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestBody UpdateUserProfileRequest request
+    ) {
+        // 1) 토큰 → userId 추출
+        String token = authorizationHeader.replace("Bearer ", "").trim();
+        String userId = jwtTokenProvider.getSubject(token);
+
+        // 2) 서비스에 수정 위임 (트랜잭션 내에서 엔티티 변경)
+        User updated = userService.updateProfile(Long.parseLong(userId), request);
+
+        // 3) 수정된 최신 정보 그대로 반환
+        return ApiResponse.success("프로필 정보가 성공적으로 수정되었습니다.",
+                new UserProfileResponse(updated));
+    }
+
+    /**
+     * 비밀번호 변경
+     * PUT /api/users/me/password
+     * @param authorizationHeader - 요청 헤더에서 액세스 토큰을 추출
+     * @param request - 현재 비밀번호와 새 비밀번호
+     * @return - 비밀번호 변경 성공 또는 실패 메시지
+     */
+    @PutMapping("/me/password")
+    public ResponseEntity<ApiResponse<?>> changePassword(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestBody UpdatePasswordRequest request) {
+
+        String token = authorizationHeader.replace("Bearer ", "").trim();
+        String userId = jwtTokenProvider.getSubject(token);  // 액세스 토큰에서 사용자 ID 추출
+
+        // 비밀번호 변경 후 마지막 변경일 반환
+        String lastModifiedDate = userService.updatePassword(userId, request);
+
+        return ResponseEntity.ok(ApiResponse.success("비밀번호가 성공적으로 변경되었습니다.", lastModifiedDate));
+    }
+}

--- a/src/main/java/com/example/musinssak/api/user/dto/AddressResponse.java
+++ b/src/main/java/com/example/musinssak/api/user/dto/AddressResponse.java
@@ -1,0 +1,38 @@
+package com.example.musinssak.api.user.dto;
+
+import com.example.musinssak.domain.user.entity.Address;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AddressResponse {
+    private Long id;
+    private String label;
+    private String recipient;
+    private String phone;
+    private String address;
+    private String detailAddress;
+    private String postalCode;
+    private boolean isDefault;
+
+    @JsonProperty("isDefault") // 응답 JSON 키를 isDefault로 고정
+    public boolean isDefault() {
+        return isDefault;
+    }
+
+    public static AddressResponse from(Address a) {
+        return AddressResponse.builder()
+                .id(a.getId())
+                .label(a.getLabel())
+                .recipient(a.getRecipient())
+                .phone(a.getPhone())
+                .address(a.getAddress())
+                .detailAddress(a.getDetailAddress())
+                .postalCode(a.getPostalCode())
+                .isDefault(a.isDefault())
+                .build();
+    }
+}

--- a/src/main/java/com/example/musinssak/api/user/dto/AddressSearchResponse.java
+++ b/src/main/java/com/example/musinssak/api/user/dto/AddressSearchResponse.java
@@ -1,0 +1,22 @@
+package com.example.musinssak.api.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class AddressSearchResponse {
+
+    private List<Item> addresses;
+
+    @Getter
+    @AllArgsConstructor
+    public static class Item {
+        private String roadAddress;   // 도로명 주소
+        private String jibunAddress;  // 지번 주소
+        private String zipCode;       // 우편번호(5자리)
+        private String buildingName;  // 건물명
+    }
+}

--- a/src/main/java/com/example/musinssak/api/user/dto/CreateAddressRequest.java
+++ b/src/main/java/com/example/musinssak/api/user/dto/CreateAddressRequest.java
@@ -1,0 +1,23 @@
+package com.example.musinssak.api.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CreateAddressRequest {
+
+    // 값이 꼭 있고, 공백 말고 실제 글자여야 한다
+    @NotBlank private String label;       // 집/회사 등
+    @NotBlank private String recipient;   // 수령인
+    @NotBlank private String phone;       // 연락처
+    @NotBlank private String postalCode;  // 우편번호
+    @NotBlank private String address;     // 기본 주소
+    private String detailAddress;         // 상세 주소(선택)
+
+    @JsonProperty("isDefault")            // 요청 본문 키 고정
+    private boolean isDefault;            // 기본 배송지로 설정 여부
+}

--- a/src/main/java/com/example/musinssak/api/user/dto/DefaultAddressUpdateResponse.java
+++ b/src/main/java/com/example/musinssak/api/user/dto/DefaultAddressUpdateResponse.java
@@ -1,0 +1,42 @@
+package com.example.musinssak.api.user.dto;
+
+import com.example.musinssak.domain.user.entity.Address;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DefaultAddressUpdateResponse {
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class Item {
+        private Long id;
+        private boolean isDefault;
+
+        @JsonProperty("isDefault") // 응답 JSON 키를 isDefault로 고정
+        public boolean isDefault() {
+            return isDefault;
+        }
+    }
+
+    private List<Item> updatedList;
+
+    public static DefaultAddressUpdateResponse from(List<Address> addresses) {
+        List<Item> items = addresses.stream()
+                .map(a -> Item.builder()
+                        .id(a.getId())
+                        .isDefault(a.isDefault())
+                        .build())
+                .toList();
+        return DefaultAddressUpdateResponse.builder()
+                .updatedList(items)
+                .build();
+    }
+}

--- a/src/main/java/com/example/musinssak/api/user/dto/UpdateAddressRequest.java
+++ b/src/main/java/com/example/musinssak/api/user/dto/UpdateAddressRequest.java
@@ -1,0 +1,23 @@
+package com.example.musinssak.api.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import lombok.*;
+
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateAddressRequest {
+
+    @NotBlank private String label;
+    @NotBlank private String recipient;
+    @NotBlank private String phone;
+    @NotBlank private String postalCode;
+    @NotBlank private String address;
+    private String detailAddress;
+
+    // 입력(JSON) → 필드 매핑 고정
+    @JsonProperty("isDefault")
+    private boolean isDefault;
+}

--- a/src/main/java/com/example/musinssak/api/user/dto/UpdatePasswordRequest.java
+++ b/src/main/java/com/example/musinssak/api/user/dto/UpdatePasswordRequest.java
@@ -1,0 +1,11 @@
+package com.example.musinssak.api.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdatePasswordRequest {
+    private String currentPassword;  // 현재 비밀번호
+    private String newPassword;      // 새 비밀번호
+}

--- a/src/main/java/com/example/musinssak/api/user/dto/UpdateUserProfileRequest.java
+++ b/src/main/java/com/example/musinssak/api/user/dto/UpdateUserProfileRequest.java
@@ -1,0 +1,23 @@
+package com.example.musinssak.api.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+/**
+ * 프로필 수정 요청 DTO
+ * - null로 오는 필드는 "변경하지 않음"
+ */
+@Getter
+@NoArgsConstructor
+public class UpdateUserProfileRequest {
+    private String name;              // 이름 (엔티티의 nickname과 매핑)
+    private String phone;             // 휴대폰 번호 (하이픈 포함된 문자열)
+
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate birthDate;      // 생년월일 (yyyy-MM-dd)
+
+    private String profileImageUrl;   // 프로필 이미지 URL (선택)
+}

--- a/src/main/java/com/example/musinssak/api/user/dto/UserProfileResponse.java
+++ b/src/main/java/com/example/musinssak/api/user/dto/UserProfileResponse.java
@@ -1,0 +1,22 @@
+package com.example.musinssak.api.user.dto;
+
+import com.example.musinssak.domain.user.entity.User;
+import lombok.Getter;
+
+@Getter
+public class UserProfileResponse {
+
+    private String name;
+    private String email;
+    private String phone;
+    private String birthDate;
+    private String profileImageUrl;
+
+    public UserProfileResponse(User user) {
+        this.name = user.getNickname();
+        this.email = user.getEmail();
+        this.phone = user.getPhone();
+        this.birthDate = user.getBirthDate() != null ? user.getBirthDate().toString() : null;
+        this.profileImageUrl = user.getProfileImageUrl();
+    }
+}

--- a/src/main/java/com/example/musinssak/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/musinssak/common/exception/ErrorCode.java
@@ -6,10 +6,13 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum ErrorCode {
 
-    // --- 인증(401) : 프론트는 이 코드만 보면 로그인 유도 ---
+    // 비밀번호 변경 관련 (400)
+    INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "INVALID_CURRENT_PASSWORD", "현재 비밀번호가 일치하지 않습니다."),
+
+    // 인증(401) : 프론트는 이 코드만 보면 로그인 유도
     AUTH_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH_REQUIRED", "로그인이 필요합니다."),
 
-    // --- 인가(403) : 로그인은 했으나 권한 부족 ---
+    // 인가(403) : 로그인은 했으나 권한 부족
     AUTH_FORBIDDEN(HttpStatus.FORBIDDEN, "AUTH_FORBIDDEN", "접근 권한이 없습니다."),
 
     // 회원가입 실패 관련
@@ -20,11 +23,22 @@ public enum ErrorCode {
     EMAIL_NOT_FOUND(HttpStatus.UNAUTHORIZED, "EMAIL_NOT_FOUND", "등록되지 않은 이메일입니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "INVALID_PASSWORD", "비밀번호가 일치하지 않습니다."),
 
-    // --- 공통 ---
+    // 사용자 프로필 관련
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자 정보를 찾을 수 없습니다."),
+
+    // 사용자 배송지 관련
+    FORBIDDEN(HttpStatus.FORBIDDEN, "FORBIDDEN", "해당 배송지에 대한 권한이 없습니다."),
+    ADDRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "ADDRESS_NOT_FOUND", "배송지를 찾을 수 없습니다."),
+    ADDRESS_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "ADDRESS_LIMIT_EXCEEDED", "배송지는 최대 5개까지 등록할 수 있습니다."),
+
+    // 주소검색
+    EMPTY_QUERY(HttpStatus.BAD_REQUEST, "EMPTY_QUERY", "검색어를 입력해주세요."),
+    NO_SEARCH_RESULT(HttpStatus.NOT_FOUND, "NO_SEARCH_RESULT", "검색 결과가 없습니다."),
+    EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "EXTERNAL_API_ERROR", "주소 검색 서비스에 일시적인 오류가 발생했습니다."),
+
+    // 공통
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "요청 형식이 잘못되었습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_SERVER_ERROR", "서버 내부 오류가 발생했습니다.");
-
-
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/musinssak/common/web/ApiResponse.java
+++ b/src/main/java/com/example/musinssak/common/web/ApiResponse.java
@@ -31,10 +31,21 @@ public class ApiResponse<T> {
         return new ApiResponse<>(200, "SUCCESS", null, message);
     }
 
+    // 201 + 메시지 (data 없음) : 배송지 추가
+    public static ApiResponse<Void> created(String message) {
+        return new ApiResponse<>(201, "SUCCESS", null, message);
+    }
+
+    // 201 + 메시지 + data (필요할 때)
+    public static <T> ApiResponse<T> created(String message, T data) {
+        return new ApiResponse<>(201, "SUCCESS", data, message);
+    }
+
     // ---------- 실패 ----------
     public static <T> ApiResponse<T> error(int status, String code, String message) {
         return new ApiResponse<>(status, code, null, message);
     }
+
 //    public static ApiResponse<Void> error(int status, String code, String message) {
 //        return new ApiResponse<>(status, code, null, message);
 //    }

--- a/src/main/java/com/example/musinssak/domain/user/entity/Address.java
+++ b/src/main/java/com/example/musinssak/domain/user/entity/Address.java
@@ -64,4 +64,14 @@ public class Address {
     }
 
     public void setDefault(boolean value) { this.isDefault = value; }
+
+    public void update(String label, String recipient, String phone,
+                       String address, String detailAddress, String postalCode) {
+        this.label = label;
+        this.recipient = recipient;
+        this.phone = phone;
+        this.address = address;
+        this.detailAddress = detailAddress;
+        this.postalCode = postalCode;
+    }
 }

--- a/src/main/java/com/example/musinssak/domain/user/entity/User.java
+++ b/src/main/java/com/example/musinssak/domain/user/entity/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 @Entity
 @Table(name = "users")
 @Getter
+@ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
@@ -57,5 +59,44 @@ public class User {
 
     public static User create(String email, String passwordHash, String nickname) {
         return new User(email, passwordHash, nickname);
+    }
+
+    // 닉네임(=이름) 변경
+    public void changeNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    // 휴대폰 변경
+    public void changePhone(String phone) {
+        this.phone = phone;
+    }
+
+    // 생년월일 변경
+    public void changeBirthDate(LocalDate birthDate) {
+        this.birthDate = birthDate;
+    }
+
+    // 프로필 이미지 URL 변경
+    public void changeProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    // updated_at 갱신
+    public void updateProfile(String nickname, String phone, LocalDate birthDate, String profileImageUrl) {
+        this.nickname = nickname;
+        this.phone = phone;
+        this.birthDate = birthDate;
+        this.profileImageUrl = profileImageUrl;
+        this.updatedAt = LocalDateTime.now(); // 현재 날짜로 갱신
+    }
+
+    // 비밀번호 변경 메서드
+    public void changePassword(String encodedNewPassword) {
+        this.passwordHash = encodedNewPassword; // 새로운 암호화된 비밀번호로 변경
+    }
+
+    // 비밀번호 변경일 갱신 메서드
+    public void setLastPasswordModifiedAt() {
+        this.lastPasswordModifiedAt = LocalDateTime.now(); // 현재 시간으로 변경일 갱신
     }
 }

--- a/src/main/java/com/example/musinssak/domain/user/repository/AddressRepository.java
+++ b/src/main/java/com/example/musinssak/domain/user/repository/AddressRepository.java
@@ -1,0 +1,95 @@
+package com.example.musinssak.domain.user.repository;
+
+import com.example.musinssak.domain.user.entity.Address;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface AddressRepository extends JpaRepository<Address, Long> {
+
+    // @ManyToOne User를 타고 들어가지만, 키만 쓰면 심플합니다.
+    // 기본배송지 우선 → 이후 최신(id desc)
+    List<Address> findByUserIdOrderByIsDefaultDescIdDesc(Long userId);
+
+    boolean existsByUserIdAndIsDefaultTrue(Long userId);
+
+    /**
+     * [벌크 UPDATE]
+     * - 특정 사용자(userId)의 '현재 기본 배송지들'을 모두 기본 해제(false)한다.
+     * - 일반적으로 0~1건이 변경된다(정상 설계면 기본은 1개뿐).
+     *
+     * 왜 벌크 UPDATE?
+     * - 엔티티를 하나하나 조회해 setDefault(false) 하는 것보다 DB에 직접 쿼리 한 번이 빠름.
+     *
+     * 주의: 벌크 UPDATE는 1차 캐시(영속성 컨텍스트)를 건너뛰므로
+     *       clearAutomatically=true로 실행 직후 캐시를 비워서 상태 불일치를 막는다.
+            *       flushAutomatically=true로 실행 전 변경분을 DB에 먼저 반영한다.
+     *
+             * @return 업데이트된 행 수(영향받은 row 수)
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Address a set a.isDefault = false where a.user.id = :userId and a.isDefault = true")
+    int clearDefaultByUserId(@Param("userId") Long userId);
+
+    /**
+     * [벌크 UPDATE]
+     * - 특정 주소 한 건을 기본 배송지(true)로 설정한다.
+     * - 권한 체크(내 소유인지) 는 서비스 계층에서 별도 검증(RBAC)하고 오도록 한다.
+     *
+     * 팁: 안전성을 더 높이려면 userId 조건까지 포함한 쿼리로 바꿀 수도 있음
+     *     (setDefaultByIdAndUserId 참고).
+     *
+     * @return 업데이트된 행 수(영향받은 row 수). 0이면 대상이 없다는 뜻.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Address a set a.isDefault = true where a.id = :addressId")
+    int setDefaultById(@Param("addressId") Long addressId);
+
+    long countByUserId(Long userId);
+
+
+    /**
+     * [벌크 UPDATE] 대상 주소 한 건을 '기본 배송지(true)'로 설정한다.
+     *
+     * 왜 userId 조건까지 포함할까?
+     * - 단순히 id만 조건으로 두면, 실수로 다른 사용자의 주소를 기본으로 만들 위험이 있다.
+     * - id + userId를 함께 걸어 '내 주소'만 변경되도록 안전하게 보장한다.
+     *
+     * @Modifying 옵션 설명
+     * - flushAutomatically = true:
+     *     이 벌크 UPDATE를 실행하기 전에, 같은 트랜잭션에서 대기 중인 변경분을 DB로 먼저 밀어넣는다.
+     *     (예: 위 서비스에서 target.update(...) 한 내용이 먼저 flush됨)
+     * - clearAutomatically = true:
+     *     벌크 UPDATE는 영속성 컨텍스트를 거치지 않고 DB만 갱신하므로
+     *     실행 직후 1차 캐시를 비워서(영속성 컨텍스트 clear) 캐시-DB 불일치를 예방한다.
+     *
+     * 반환값(int)
+     * - 영향을 받은 행(row) 수를 반환한다.
+     * - 0이면 조건에 맞는 행이 없다는 뜻(잘못된 addressId이거나 소유자 불일치).
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Address a set a.isDefault = true " +
+            "where a.id = :addressId and a.user.id = :userId")
+    int setDefaultByIdAndUserId(@Param("addressId") Long addressId,
+                                @Param("userId") Long userId);
+
+    /**
+     * [삭제 보조용 조회]
+     * - 특정 사용자(userId)의 주소들 중에서,
+     *   현재 삭제 대상 addressId를 "제외"하고
+     *   id 오름차순으로 가장 앞(가장 작은 id) 한 건을 가져온다.
+     *
+     * 사용 시나리오:
+     * - 삭제 전에 내 주소 개수가 2개였을 때 → 삭제 후 정확히 1개가 남는다.
+     * - 그 "남는 한 건"을 자동 기본으로 설정하기 위해 미리 찾아두는 용도.
+     *
+     * 반환:
+     * - Optional<Address> (이론상 거의 항상 1건 존재)
+     * - 서비스에서 .map(Address::getId)로 id만 뽑아 사용
+     */
+    Optional<Address> findFirstByUserIdAndIdNotOrderByIdAsc(Long userId, Long addressId);
+}

--- a/src/main/java/com/example/musinssak/domain/user/service/AddressSearchService.java
+++ b/src/main/java/com/example/musinssak/domain/user/service/AddressSearchService.java
@@ -1,0 +1,7 @@
+package com.example.musinssak.domain.user.service;
+
+import com.example.musinssak.api.user.dto.AddressSearchResponse;
+
+public interface AddressSearchService {
+    AddressSearchResponse search(String query);
+}

--- a/src/main/java/com/example/musinssak/domain/user/service/AddressSearchServiceImpl.java
+++ b/src/main/java/com/example/musinssak/domain/user/service/AddressSearchServiceImpl.java
@@ -1,0 +1,37 @@
+package com.example.musinssak.domain.user.service;
+
+import com.example.musinssak.api.user.dto.AddressSearchResponse;
+import com.example.musinssak.infra.external.kakao.KakaoAddressClient;
+import com.example.musinssak.infra.external.kakao.KakaoAddressSearchDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AddressSearchServiceImpl implements AddressSearchService {
+
+    private final KakaoAddressClient kakaoAddressClient;
+
+    @Override
+    public AddressSearchResponse search(String query) {
+        // 1) 카카오 주소검색 API 호출
+        KakaoAddressSearchDto searchResult = kakaoAddressClient.searchAddress(query, 10);
+
+        // 2) 응답 -> 우리 DTO로 가공
+        List<AddressSearchResponse.Item> items = new ArrayList<>();
+        for (KakaoAddressSearchDto.Document document : searchResult.getDocuments()) {
+            String roadAddress = document.getRoadAddress() != null ? document.getRoadAddress().getAddressName() : null;
+            String jibunAddress = document.getJibunAddress() != null ? document.getJibunAddress().getAddressName() : null;
+            String zip = document.getRoadAddress() != null ? document.getRoadAddress().getZoneNo() : null;
+            String building = document.getRoadAddress() != null ? document.getRoadAddress().getBuildingName() : null;
+
+            if (roadAddress != null || jibunAddress != null) {
+                items.add(new AddressSearchResponse.Item(roadAddress, jibunAddress, zip, building));
+            }
+        }
+        return new AddressSearchResponse(items);
+    }
+}

--- a/src/main/java/com/example/musinssak/domain/user/service/AddressService.java
+++ b/src/main/java/com/example/musinssak/domain/user/service/AddressService.java
@@ -1,0 +1,20 @@
+package com.example.musinssak.domain.user.service;
+
+import com.example.musinssak.api.user.dto.AddressResponse;
+import com.example.musinssak.api.user.dto.CreateAddressRequest;
+import com.example.musinssak.api.user.dto.DefaultAddressUpdateResponse;
+import com.example.musinssak.api.user.dto.UpdateAddressRequest;
+
+import java.util.List;
+
+public interface AddressService {
+    List<AddressResponse> getMyAddresses(Long userId);
+
+    DefaultAddressUpdateResponse setDefaultAddress(Long userId, Long addressId);
+
+    void createAddress(Long userId, CreateAddressRequest request);
+
+    void updateAddress(Long userId, Long addressId, UpdateAddressRequest request);
+
+    void deleteAddress(Long userId, Long addressId);
+}

--- a/src/main/java/com/example/musinssak/domain/user/service/AddressServiceImpl.java
+++ b/src/main/java/com/example/musinssak/domain/user/service/AddressServiceImpl.java
@@ -1,0 +1,206 @@
+package com.example.musinssak.domain.user.service;
+
+import com.example.musinssak.api.user.dto.AddressResponse;
+import com.example.musinssak.api.user.dto.CreateAddressRequest;
+import com.example.musinssak.api.user.dto.DefaultAddressUpdateResponse;
+import com.example.musinssak.api.user.dto.UpdateAddressRequest;
+import com.example.musinssak.common.exception.BusinessException;
+import com.example.musinssak.common.exception.ErrorCode;
+import com.example.musinssak.domain.user.entity.Address;
+import com.example.musinssak.domain.user.entity.User;
+import com.example.musinssak.domain.user.repository.AddressRepository;
+import com.example.musinssak.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AddressServiceImpl implements AddressService {
+
+    private final AddressRepository addressRepository;
+    private final UserRepository userRepository;
+
+    private static final int MAX_ADDRESS_COUNT = 5;
+
+    @Override
+    public List<AddressResponse> getMyAddresses(Long userId) {
+        // 요구사항: 사용자 없으면 404 USER_NOT_FOUND
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        return addressRepository.findByUserIdOrderByIsDefaultDescIdDesc(user.getId())
+                .stream().map(AddressResponse::from).toList();
+    }
+
+    @Transactional
+    @Override
+    public DefaultAddressUpdateResponse setDefaultAddress(Long userId, Long addressId) {
+        // 1) 사용자 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 2) 대상 주소 확인 (404)
+        Address target = addressRepository.findById(addressId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ADDRESS_NOT_FOUND));
+
+        // 3) 권한 체크 (403) - 내 주소인지
+        if (!target.getUser().getId().equals(user.getId())) {
+            // ErrorCode에 FORBIDDEN 또는 AUTH_FORBIDDEN 중 하나를 사용하세요.
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        // 4) 단일성 보장: 내 모든 기본배송지 해제 → 대상만 true
+        addressRepository.clearDefaultByUserId(userId);
+        int changed = addressRepository.setDefaultById(addressId);
+        if (changed == 0) {
+            // 이 경우는 논리적으로 거의 없지만, 방어적으로 404 처리
+            throw new BusinessException(ErrorCode.ADDRESS_NOT_FOUND);
+        }
+
+        // 5) 변경 후 목록 재조회하여 응답 구성 (정렬: 기본배송지 우선, 최신순)
+        var after = addressRepository.findByUserIdOrderByIsDefaultDescIdDesc(userId);
+        return DefaultAddressUpdateResponse.from(after);
+    }
+
+    @Override
+    @Transactional
+    public void createAddress(Long userId, CreateAddressRequest request) {
+        // 1) 사용자 확인 (없으면 404)
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 2) 최대 5개 제한
+        long count = addressRepository.countByUserId(userId);
+        if (count >= MAX_ADDRESS_COUNT) {
+            throw new BusinessException(ErrorCode.ADDRESS_LIMIT_EXCEEDED);
+        }
+
+        // 3) 기본 설정 여부 결정
+        //   - 첫 주소면 자동 기본
+        //   - 요청 isDefault=true면 기존 기본 해제 후 신규를 기본으로
+        boolean makeDefault = (count == 0) || request.isDefault();
+        if (makeDefault) {
+            addressRepository.clearDefaultByUserId(userId); // 기존 기본 해제
+        }
+
+        // 4) 저장
+        Address address = Address.builder()
+                .user(user)
+                .label(request.getLabel())
+                .recipient(request.getRecipient())
+                .phone(request.getPhone())
+                .postalCode(request.getPostalCode())
+                .address(request.getAddress())
+                .detailAddress(request.getDetailAddress())
+                .isDefault(makeDefault)
+                .build();
+
+        addressRepository.save(address);
+    }
+
+    @Override
+    @Transactional
+    public void updateAddress(Long userId, Long addressId, UpdateAddressRequest req) {
+        // [1] 사용자/주소 존재 여부 확인 -------------------------
+        // - 사용자 없으면 404(USER_NOT_FOUND)
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // - 수정할 주소가 없으면 404(ADDRESS_NOT_FOUND)
+        Address target = addressRepository.findById(addressId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ADDRESS_NOT_FOUND));
+
+        // - 이 주소의 소유자가 '나'인지 확인 (RBAC)
+        //   아니면 403(FORBIDDEN)
+        if (!target.getUser().getId().equals(user.getId())) {
+            throw new BusinessException(ErrorCode.FORBIDDEN);
+        }
+
+        // [2] 내용 수정 -----------------------------------------
+        // - 엔티티 도메인 메서드로 필드값 변경
+        // - 영속 상태라서 트랜잭션 커밋 시점에 자동으로 UPDATE 쿼리가 나감
+        target.update(
+                req.getLabel(),
+                req.getRecipient(),
+                req.getPhone(),
+                req.getAddress(),
+                req.getDetailAddress(),
+                req.getPostalCode()
+        );
+
+        // [3] 기본 배송지 규칙 처리 ------------------------------
+        // - 내 주소 개수 조회 (1개뿐이면 무조건 기본)
+        long count = addressRepository.countByUserId(userId);
+
+        // makeDefault = (주소가 1개뿐) 또는 (요청에서 isDefault=true)
+        boolean makeDefault = (count == 1) || req.isDefault();
+        if (makeDefault) {
+            // 3-1) 기존 기본 해제 → 대상만 기본으로 설정
+            //  - 아래 두 메서드는 JPQL "벌크 UPDATE"라서 엔티티를 거치지 않고 DB를 직접 갱신함
+            //  - Repository 쿼리에 @Modifying(flushAutomatically=true, clearAutomatically=true)를
+            //    걸어두었기 때문에,
+            //    (a) 먼저 영속성 컨텍스트의 변경분을 DB에 flush하고
+            //    (b) 벌크 UPDATE 실행 직후 1차 캐시를 비워 상태 불일치를 방지함
+            addressRepository.clearDefaultByUserId(userId);          // 내 기존 기본들 false
+            addressRepository.setDefaultByIdAndUserId(addressId, userId); // 대상만 true
+        } else {
+            // 3-2) 요청이 isDefault=false 인데, 현재 대상이 기본이고,
+            //      다른 주소가 1개 이상 있을 때 → 기본 해제
+            if (target.isDefault() && count > 1) {
+                // 엔티티 플래그만 내려도 됨 (영속 상태 → 커밋 시 UPDATE)
+                target.setDefault(false);
+            }
+        }
+        // ※ 이 메서드는 별도 반환값이 없고, 컨트롤러에서 "성공 메시지"만 내려줌
+    }
+
+    @Override
+    @Transactional
+    public void deleteAddress(Long userId, Long addressId) {
+        // [1] 사용자/주소 존재 및 소유권 확인 -------------------------
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        Address target = addressRepository.findById(addressId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.ADDRESS_NOT_FOUND));
+
+        if (!target.getUser().getId().equals(user.getId())) {
+            throw new BusinessException(ErrorCode.FORBIDDEN); // 내 주소가 아니면 삭제 불가
+        }
+
+        // [2] 삭제 전 개수 파악 ------------------------------------
+        // - 삭제 정책은 "삭제 이후 남은 개수"에 따라 달라짐
+        // - delete() 전에 미리 개수를 구해 두면 flush 타이밍에 덜 민감
+        long beforeCount = addressRepository.countByUserId(userId);
+
+        // 남은 주소가 1개가 될 상황인지 미리 판단 (삭제 전 개수가 2라면, 삭제 후 1개)
+        boolean willRemainExactlyOne = (beforeCount == 2);
+
+        // (선택) 남은 1개가 될 경우를 대비해 "살아남을 주소"의 id를 미리 조회
+        //  - flush 타이밍 이슈 없이 바로 기본으로 지정 가능
+        Long survivorId = null;
+        if (willRemainExactlyOne) {
+            survivorId = addressRepository
+                    .findFirstByUserIdAndIdNotOrderByIdAsc(userId, addressId)
+                    .map(Address::getId)
+                    .orElse(null); // 이 null은 논리상 거의 발생하지 않음
+        }
+
+        // [3] 실제 삭제 -------------------------------------------
+        addressRepository.delete(target); // 영속 상태 엔티티 삭제 → 커밋 시점에 DELETE
+
+        // [4] 삭제 후 정책 적용 ------------------------------------
+        if (willRemainExactlyOne && survivorId != null) {
+            // 삭제 후 1개만 남음 → 그 주소를 "자동 기본"으로 설정
+            // 벌크 UPDATE 사용: 빠르고, userId 조건까지 걸어 안전성 ↑
+            addressRepository.setDefaultByIdAndUserId(survivorId, userId);
+            // (2개 이상 남는 케이스는 기본 배송지 없음 상태도 허용하므로 추가 작업 없음)
+        }
+
+        // ※ 삭제 후 남은 주소가 0개인 경우: 설정할 기본이 없으므로 아무 작업도 하지 않음
+    }
+}

--- a/src/main/java/com/example/musinssak/domain/user/service/UserService.java
+++ b/src/main/java/com/example/musinssak/domain/user/service/UserService.java
@@ -1,9 +1,19 @@
 package com.example.musinssak.domain.user.service;
 
+import com.example.musinssak.api.user.dto.UpdatePasswordRequest;
+import com.example.musinssak.api.user.dto.UpdateUserProfileRequest;
 import com.example.musinssak.domain.user.entity.User;
+
+import java.util.Optional;
 
 public interface UserService {
     boolean emailExists(String email);
     boolean nicknameExists(String nickname);
     User createUser(String email, String passwordHash, String nickname);
+
+    User getUserById(long userId);
+
+    User updateProfile(long parseLong, UpdateUserProfileRequest request);
+
+    String updatePassword(String userId, UpdatePasswordRequest request);
 }

--- a/src/main/java/com/example/musinssak/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/musinssak/domain/user/service/UserServiceImpl.java
@@ -1,8 +1,13 @@
 package com.example.musinssak.domain.user.service;
 
+import com.example.musinssak.api.user.dto.UpdatePasswordRequest;
+import com.example.musinssak.api.user.dto.UpdateUserProfileRequest;
+import com.example.musinssak.common.exception.BusinessException;
+import com.example.musinssak.common.exception.ErrorCode;
 import com.example.musinssak.domain.user.entity.User;
 import com.example.musinssak.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -12,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     @Override
     public boolean emailExists(String email) {
@@ -27,5 +33,56 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public User createUser(String email, String passwordHash, String nickname) {
         return userRepository.save(User.create(email, passwordHash, nickname));
+    }
+
+    @Override
+    public User getUserById(long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    @Override
+    @Transactional
+    public User updateProfile(long userId, UpdateUserProfileRequest req) {
+        // 1) 대상 유저 조회 (없으면 404)
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 2) 전달된 값이 있을 때만 갱신 (null이면 기존 값 유지)
+        if (req.getName() != null) user.changeNickname(req.getName()); // name -> nickname
+        if (req.getPhone() != null) user.changePhone(req.getPhone());
+        if (req.getBirthDate() != null) user.changeBirthDate(req.getBirthDate());
+        if (req.getProfileImageUrl() != null) user.changeProfileImageUrl(req.getProfileImageUrl());
+
+        // 3) updated_at은 자동 갱신되도록 처리됨
+        user.updateProfile(req.getName(), req.getPhone(), req.getBirthDate(), req.getProfileImageUrl());
+
+        // 4) @Transactional로 관리되므로 반환만 하면됨 (save 불필요)
+        return user;
+    }
+
+    @Transactional
+    public String updatePassword(String userId, UpdatePasswordRequest request) {
+        // 1) 사용자 조회
+        User user = userRepository.findById(Long.parseLong(userId))
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        // 2) 현재 비밀번호가 일치하는지 확인
+        if (!passwordEncoder.matches(request.getCurrentPassword(), user.getPasswordHash())) {
+            throw new BusinessException(ErrorCode.INVALID_CURRENT_PASSWORD);  // 현재 비밀번호 불일치
+        }
+
+        // 3) 새 비밀번호 설정
+        String encodedNewPassword = passwordEncoder.encode(request.getNewPassword());
+        user.changePassword(encodedNewPassword);
+
+        // 4) 비밀번호 변경일 갱신
+        user.setLastPasswordModifiedAt();
+
+        // 5) 저장
+        userRepository.save(user);
+
+        // 6) 마지막 변경일 반환 (yyyy-MM-dd 형식으로)
+        return user.getLastPasswordModifiedAt().toLocalDate().toString();
     }
 }

--- a/src/main/java/com/example/musinssak/infra/config/AppConfig.java
+++ b/src/main/java/com/example/musinssak/infra/config/AppConfig.java
@@ -1,0 +1,14 @@
+package com.example.musinssak.infra.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/example/musinssak/infra/external/kakao/KakaoAddressClient.java
+++ b/src/main/java/com/example/musinssak/infra/external/kakao/KakaoAddressClient.java
@@ -1,0 +1,52 @@
+package com.example.musinssak.infra.external.kakao;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoAddressClient {
+
+    private final RestTemplate restTemplate;
+    private final KakaoLocalProperties kakaoLocalProperties;
+
+    /**
+     * 카카오 로컬 주소검색 API 호출
+     * GET {baseUrl}/v2/local/search/address.json?query={query}
+     * @param query 검색어 (예: "서울 강남구")
+     * @param size 검색 결과 최대 개수 (기본 10)
+     * @return 카카오 주소검색 API의 응답
+     */
+    public KakaoAddressSearchDto searchAddress(String query, int size) {
+        String url = UriComponentsBuilder
+                .fromHttpUrl(kakaoLocalProperties.getBaseUrl())
+                .path("/v2/local/search/address.json")
+                .queryParam("query", query)
+                .queryParam("size", size)   // 검색 결과 개수
+                .build().toUriString();
+
+        // 헤더 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(HttpHeaders.AUTHORIZATION, "KakaoAK " + kakaoLocalProperties.getRestApiKey());
+        headers.set(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE);
+
+        HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+        try {
+            // GET 요청 보내기
+            ResponseEntity<KakaoAddressSearchDto> response =
+                    restTemplate.exchange(url, HttpMethod.GET, entity, KakaoAddressSearchDto.class);
+
+            // 응답 반환
+            return response.getBody();
+        } catch (Exception e) {
+            log.error("주소 검색 API 호출 실패: {}", e.getMessage(), e);
+            throw new RuntimeException("주소 검색 서비스 오류");
+        }
+    }
+}

--- a/src/main/java/com/example/musinssak/infra/external/kakao/KakaoAddressSearchDto.java
+++ b/src/main/java/com/example/musinssak/infra/external/kakao/KakaoAddressSearchDto.java
@@ -1,0 +1,33 @@
+package com.example.musinssak.infra.external.kakao;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class KakaoAddressSearchDto {
+
+    private List<Document> documents;
+
+    @Getter
+    public static class Document {
+        @JsonProperty("road_address")
+        private RoadAddress roadAddress;
+
+        @JsonProperty("address")
+        private JibunAddress jibunAddress;
+    }
+
+    @Getter
+    public static class RoadAddress {
+        @JsonProperty("address_name") private String addressName;
+        @JsonProperty("building_name") private String buildingName;
+        @JsonProperty("zone_no") private String zoneNo;
+    }
+
+    @Getter
+    public static class JibunAddress {
+        @JsonProperty("address_name") private String addressName;
+    }
+}

--- a/src/main/java/com/example/musinssak/infra/external/kakao/KakaoLocalConfigTest.java
+++ b/src/main/java/com/example/musinssak/infra/external/kakao/KakaoLocalConfigTest.java
@@ -1,0 +1,23 @@
+package com.example.musinssak.infra.external.kakao;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KakaoLocalConfigTest {
+
+    private final KakaoLocalProperties kakaoLocalProperties;
+
+    @PostConstruct
+    public void checkConfig() {
+        // Kakao Base URL: https://dapi.kakao.com
+        log.info("Kakao Base URL: {}", kakaoLocalProperties.getBaseUrl());
+        // Kakao REST API Key: Loaded
+        log.info("Kakao REST API Key: {}", kakaoLocalProperties.getRestApiKey() != null ? "Loaded" : "Not Loaded");
+    }
+}

--- a/src/main/java/com/example/musinssak/infra/external/kakao/KakaoLocalProperties.java
+++ b/src/main/java/com/example/musinssak/infra/external/kakao/KakaoLocalProperties.java
@@ -1,0 +1,15 @@
+package com.example.musinssak.infra.external.kakao;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component  // 이 클래스가 스프링 빈으로 등록되게 함
+@ConfigurationProperties(prefix = "kakao.local")  // yml에서 kakao.local로 시작하는 값을 읽어옵니다.
+public class KakaoLocalProperties {
+    private String baseUrl;      // 주소검색 API 기본 URL
+    private String restApiKey;   // 카카오 REST API 키
+}

--- a/src/main/java/com/example/musinssak/infra/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/musinssak/infra/security/JwtAuthenticationFilter.java
@@ -6,7 +6,9 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -28,6 +30,7 @@ import java.util.List;
  *     - 유효하지 않거나 만료/파싱오류면 요청에 AUTH_REQUIRED 표식만 남김
  *  4) 최종 401 JSON 응답은 SecurityConfig의 authenticationEntryPoint가 통일해서 내려줌
  */
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -90,6 +93,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 );
                 authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
                 SecurityContextHolder.getContext().setAuthentication(authentication);
+
+//                Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+//                String username = auth.getName(); // 로그인한 유저 이름
+//                log.info("[JWT] auth.getName()={}", username);
 
                 // 유효한 토큰이면 끝. 다음 필터로 진행
                 filterChain.doFilter(request, response);


### PR DESCRIPTION
[작업한 내용]

- 프로필
GET/PUT /api/users/me/profile, PUT /api/users/me/password

- 배송지
GET/POST/PUT/DELETE /api/users/me/addresses
기본배송지 설정: PUT /api/users/me/addresses/{id}/default
규칙: 첫 등록 자동 기본, 동시에 1개, 최대 5개

- 주소검색(외부)
GET /api/address/search?query=... (road/jibun/zip/building 반환)

- 인프라
KakaoAddressClient 연동, RestTemplate Bean, kakao.local 설정(yml)

[참고사항]
- .env에 KAKAO_REST_API_KEY 필요, /api/address/search는 공개
- 배송지 추가/수정/삭제 후 목록 재조회 권장