### PR TITLE
chore: springdoc 기본 설정 추가 (Swagger UI, OpenAPIConfig)

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -47,10 +47,18 @@ spring:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.apache.kafka.common.serialization.StringSerializer
 
-# Swagger Configuration
+# Swagger Configuration -> 배포 전(application.yml 하나로 유지)
 springdoc:
+  api-docs:
+    enabled: true
+    path: /v3/api-docs
   swagger-ui:
+    enabled: true
     path: /swagger-ui.html
+    doc-expansion: none
+    display-request-duration: true
+    operations-sorter: alpha
+    tags-sorter: alpha
 
 # Logging Configuration
 logging:

--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     // Swagger/OpenAPI
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.12'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/example/musinssak/infra/openapi/OpenApiConfig.java
+++ b/src/main/java/com/example/musinssak/infra/openapi/OpenApiConfig.java
@@ -1,0 +1,32 @@
+package com.example.musinssak.infra.openapi;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfig {
+
+    private static final String SCHEME = "BearerAuth";
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info().title("Musinsa Shop API").version("v1"))
+                .components(new Components().addSecuritySchemes(
+                        SCHEME,
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                ))
+                // 전역 보호(전체 API에 Authorization 적용). 특정 API만 보호하고 싶으면 이 줄 빼고 메서드에 @SecurityRequirement 사용.
+                .security(List.of(new SecurityRequirement().addList(SCHEME)));
+    }
+}

--- a/src/main/java/com/example/musinssak/infra/security/SecurityConfig.java
+++ b/src/main/java/com/example/musinssak/infra/security/SecurityConfig.java
@@ -80,20 +80,20 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/auth/logout").permitAll()
 
                         // 내 정보 / 배송지 / 계정 보안
-                        .requestMatchers("/api/users/me/**").permitAll()
+                        .requestMatchers("/api/users/me/**").authenticated()
 
                         // 상품 문의 등록(POST만 보호)
-                        .requestMatchers(HttpMethod.POST, "/api/products/*/questions").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/products/*/questions").authenticated()
 
                         // 찜/최근 본 상품
-                        .requestMatchers("/api/users/me/wishlist/**").permitAll()
-                        .requestMatchers("/api/users/me/recent-products/**").permitAll()
+                        .requestMatchers("/api/users/me/wishlist/**").authenticated()
+                        .requestMatchers("/api/users/me/recent-products/**").authenticated()
 
                         // 장바구니
-                        .requestMatchers("/api/cart/**").permitAll()
+                        .requestMatchers("/api/cart/**").authenticated()
 
                         // 주문
-                        .requestMatchers("/api/orders/**").permitAll()
+                        .requestMatchers("/api/orders/**").authenticated()
 
                         /* ---------- ③ 그 외 ---------- */
                         .anyRequest().permitAll() // 개발 단계: 나머지는 공개. 필요 시 authenticated()로 전환


### PR DESCRIPTION
[작업한 내용]
- springdoc-openapi 의존성 적용 및 버전 업 (2.8.12)
- application.yml 에 Swagger UI 접근 경로 및 옵션 추가
- OpenApiConfig 클래스 추가 (JWT Bearer 인증 연동)
- Swagger 경로(/v3/api-docs/**, /swagger-ui/**) SecurityConfig에서 허용

[참고사항]
- 현재는 dev 환경에서 Swagger 항상 켜짐
- 배포 환경(prod)에서는 application-prod.yml 에서 Swagger OFF 예정
- Swagger UI 테스트 시 Authorize 버튼에 JWT 토큰 입력 필요