### PR TITLE
feat: 상품 리뷰 목록 조회 API 구현 (페이징/정렬/집계)

### DIFF
--- a/src/main/java/com/example/musinssak/api/review/ReviewController.java
+++ b/src/main/java/com/example/musinssak/api/review/ReviewController.java
@@ -1,0 +1,47 @@
+package com.example.musinssak.api.review;
+
+import com.example.musinssak.api.review.dto.ReviewListResponse;
+import com.example.musinssak.api.review.dto.SortType;
+import com.example.musinssak.api.review.facade.ReviewQueryFacade;
+import com.example.musinssak.common.web.ApiResponse;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/products/{productId}/reviews")
+public class ReviewController {
+
+    private final ReviewQueryFacade reviewQueryFacade;
+
+    /**
+     * 상품 리뷰 목록 조회
+     * GET /api/products/{productId}/reviews
+     *
+     * @param productId 조회할 상품 ID
+     * @param sort 정렬 기준 (latest, high, low) - 기본값 latest
+     * @param page 페이지 번호 (1부터 시작)
+     * @param size 페이지당 리뷰 개수
+     * @return 상품 리뷰 목록과 요약 통계, 페이지 정보
+     */
+    @GetMapping
+    public ResponseEntity<ApiResponse<ReviewListResponse>> getProductReviews(
+            @PathVariable("productId") Long productId,
+            @RequestParam(name = "sort", required = false, defaultValue = "latest") String sort,
+            @RequestParam(name = "page") @Min(1) int page,
+            @RequestParam(name = "size") @Min(1) int size
+    ) {
+        SortType sortType = SortType.from(sort);
+        int zeroBasedPage = page - 1;
+
+        ReviewListResponse data = reviewQueryFacade.getProductReviews(
+                productId, sortType, zeroBasedPage, size
+        );
+
+        return ResponseEntity.ok(
+                ApiResponse.success("상품 리뷰 목록을 성공적으로 조회했습니다.", data)
+        );
+    }
+}

--- a/src/main/java/com/example/musinssak/api/review/dto/ReviewItem.java
+++ b/src/main/java/com/example/musinssak/api/review/dto/ReviewItem.java
@@ -1,0 +1,13 @@
+package com.example.musinssak.api.review.dto;
+
+import lombok.Builder;
+
+@Builder
+public record ReviewItem(
+        Long id,
+        Integer rating,
+        String author,     // 마스킹된 닉네임
+        Boolean hasPhoto,
+        String content,
+        String createdAt   // yyyy-MM-dd
+) {}

--- a/src/main/java/com/example/musinssak/api/review/dto/ReviewListResponse.java
+++ b/src/main/java/com/example/musinssak/api/review/dto/ReviewListResponse.java
@@ -1,0 +1,34 @@
+package com.example.musinssak.api.review.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+import java.util.Map;
+
+@Builder
+public record ReviewListResponse(
+        // 상품 식별자 (DB PK) → 보통 null은 없지만,
+        // DTO 조립 중 세팅 안 됐을 수도 있어 null 허용(Long) 사용
+        Long productId,
+
+        // 총 리뷰 수 → "없음"은 없고 최소 0은 항상 존재하므로 primitive long
+        long totalReviews,
+
+        // 평균 별점 → 항상 값이 있음 (없으면 0.0으로 치환하므로 primitive double)
+        double averageRating,
+
+        // 별점 분포 (5~1) → 맵이 반드시 존재 (없으면 빈 맵 보정)
+        Map<String, Integer> ratingDistribution,
+
+        // 리뷰 항목 리스트 (없으면 빈 리스트로 내려감)
+        List<ReviewItem> reviews,
+
+        // 페이지 번호 → 요청에서 필수, null 불가이므로 primitive int (1-based 응답)
+        int page,
+
+        // 페이지 크기 → 요청에서 필수, null 불가이므로 primitive int
+        int size,
+
+        // 다음 페이지 여부 → 항상 true/false가 존재하므로 primitive boolean
+        boolean hasNext
+) {}

--- a/src/main/java/com/example/musinssak/api/review/dto/SortType.java
+++ b/src/main/java/com/example/musinssak/api/review/dto/SortType.java
@@ -1,0 +1,18 @@
+package com.example.musinssak.api.review.dto;
+
+import java.util.Locale;
+
+public enum SortType {
+    LATEST, HIGH, LOW;
+
+    public static SortType from(String raw) {
+        if (raw == null) return LATEST;
+        String key = raw.trim().toLowerCase(Locale.ROOT);
+        return switch (key) {
+            case "latest" -> LATEST;
+            case "high"   -> HIGH;
+            case "low"    -> LOW;
+            default       -> LATEST; // 잘못된 값은 latest로 처리
+        };
+    }
+}

--- a/src/main/java/com/example/musinssak/api/review/facade/ReviewQueryFacade.java
+++ b/src/main/java/com/example/musinssak/api/review/facade/ReviewQueryFacade.java
@@ -1,0 +1,9 @@
+package com.example.musinssak.api.review.facade;
+
+import com.example.musinssak.api.review.dto.ReviewListResponse;
+import com.example.musinssak.api.review.dto.SortType;
+import jakarta.validation.constraints.Min;
+
+public interface ReviewQueryFacade {
+    ReviewListResponse getProductReviews(Long productId, SortType sortType, int zeroBasedPage, @Min(1) int size);
+}

--- a/src/main/java/com/example/musinssak/api/review/facade/ReviewQueryFacadeImpl.java
+++ b/src/main/java/com/example/musinssak/api/review/facade/ReviewQueryFacadeImpl.java
@@ -1,0 +1,98 @@
+package com.example.musinssak.api.review.facade;
+
+import com.example.musinssak.api.review.dto.ReviewItem;
+import com.example.musinssak.api.review.dto.ReviewListResponse;
+import com.example.musinssak.api.review.dto.SortType;
+import com.example.musinssak.common.util.DateFormatters;
+import com.example.musinssak.common.util.NameMasker;
+import com.example.musinssak.common.util.RatingUtils;
+import com.example.musinssak.common.util.ReviewSorts;
+import com.example.musinssak.domain.product.service.ProductQueryService;
+import com.example.musinssak.domain.review.repository.ReviewRepository;
+import com.example.musinssak.domain.review.service.ReviewQueryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.type.descriptor.DateTimeUtils;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReviewQueryFacadeImpl implements ReviewQueryFacade {
+
+    // [1] 파사드는 "서비스들을 조립"하는 계층이므로, 비즈니스 로직을 가진 서비스에만 의존한다.
+    private final ProductQueryService productQueryService; // 상품 존재 검증
+    private final ReviewQueryService reviewQueryService;   // 리뷰 집계/목록 조회
+
+    /**
+     * 파사드에서 하는 일(조립 순서)
+     *  1) 상품 존재 검증 (공통 예외핸들러에서 처리)
+     *  2) 리뷰 "집계" 조회: 총개수, 평균(원시값), 별점 분포(1~5 정수키)
+     *  3) 집계값을 API 명세 포맷으로 변환:
+     *      - 평균 반올림(소수 1자리)
+     *      - 분포 키를 문자열 "5"~"1"로 변환 + 누락키 0 채우기
+     *  4) 정렬 규칙 생성(동점 시 최신우선) 후 "리뷰 목록 페이지" 조회
+     *  5) 목록 Row -> 응답 DTO(ReviewItem)로 변환:
+     *      - 작성자 이름 마스킹
+     *      - 날짜 yyyy-MM-dd 포맷
+     *  6) 최종 응답 DTO(ReviewListResponse) 조립:
+     *      - page는 응답에서 1-based로 복원
+     *      - hasNext는 Page.hasNext()로 세팅
+     */
+    @Override
+    public ReviewListResponse getProductReviews(Long productId, SortType sortType,
+                                                int zeroBasedPage, int size) {
+        // 1) 상품 존재 검증 (없으면 404 예외)
+        productQueryService.assertExists(productId);
+
+        // 2-1) 총 리뷰 수 집계
+        long totalReviews = reviewQueryService.getTotalCount(productId);
+
+        // 2-2) 평균 별점(원시값) 조회 - null 가능
+        Double avgRaw = reviewQueryService.getAverageRatingRaw(productId);
+
+        // 2-3) 별점 분포 집계 (정수 키), 반환값 {5=89, 4=25, 3=13 ...}
+        Map<Integer, Integer> distRaw = reviewQueryService.getRatingDistribution(productId);
+
+        // 3) 집계값을 API 명세 포맷으로 변환
+        double average = (avgRaw == null) ? 0.0 : RatingUtils.round1(avgRaw);
+        Map<String, Integer> distribution = RatingUtils.fillDistribution(distRaw);
+
+        // 4) 정렬 스펙 생성 → 목록 페이지 조회
+        var sort = ReviewSorts.toNativeSort(sortType);
+        Page<ReviewRepository.ReviewListRow> pageRows =
+                reviewQueryService.getReviewPage(productId, zeroBasedPage, size, sort);
+
+        // 5) 목록 Row -> 응답 DTO(ReviewItem)로 변환
+        List<ReviewItem> items = pageRows.getContent().stream()
+                .map(row -> {
+                    boolean hasPhoto = row.getHasPhoto() != null && row.getHasPhoto().intValue() == 1;
+                    return ReviewItem.builder()
+                            .id(row.getId())
+                            .rating(row.getRating())
+                            .author(NameMasker.mask(row.getAuthorName()))
+                            .hasPhoto(hasPhoto)                              // ← 여기!
+                            .content(row.getContent())
+                            .createdAt(DateFormatters.toYMD(row.getCreatedAt()))
+                            .build();
+                })
+                .toList();
+
+
+        // 6) 최종 응답 DTO 조립
+        return ReviewListResponse.builder()
+                .productId(productId)
+                .totalReviews(totalReviews)
+                .averageRating(average)
+                .ratingDistribution(distribution)
+                .reviews(items)
+                .page(zeroBasedPage + 1)          // 응답에서는 1-based
+                .size(size)
+                .hasNext(pageRows.hasNext())      // 다음 페이지 여부
+                .build();
+    }
+}

--- a/src/main/java/com/example/musinssak/common/util/DateFormatters.java
+++ b/src/main/java/com/example/musinssak/common/util/DateFormatters.java
@@ -1,0 +1,19 @@
+package com.example.musinssak.common.util;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+// 날짜 포맷 유틸 (yyyy-MM-dd)
+public final class DateFormatters {
+
+    private DateFormatters() {}
+
+    private static final ZoneId ZONE = ZoneId.systemDefault(); // 필요시 KST로 고정 가능
+    private static final DateTimeFormatter YMD = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    public static String toYMD(LocalDateTime time) {
+        if (time == null) return null;
+        return time.atZone(ZONE).format(YMD);
+    }
+}

--- a/src/main/java/com/example/musinssak/common/util/NameMasker.java
+++ b/src/main/java/com/example/musinssak/common/util/NameMasker.java
@@ -1,0 +1,33 @@
+package com.example.musinssak.common.util;
+
+import java.util.Objects;
+
+
+// 작성자 이름 마스킹 유틸
+public final class NameMasker {
+
+    private NameMasker() {}
+
+    /**
+     * 간단 규칙(명세 예시 "김**"):
+     * - 길이 1: 그대로 반환 (ex. "김")
+     * - 길이 2: 첫 글자 + "*" (ex. "김철" -> "김*")
+     * - 길이 ≥3: 앞 1~2글자 노출, 나머지 "*" 채움
+     *   - 한글/영문 모두 동일하게 처리
+     */
+    public static String mask(String displayName) {
+        if (displayName == null) return "";
+        String name = displayName.trim();
+        if (name.isEmpty()) return "";
+
+        int len = name.length();
+        if (len == 1) return name;
+        if (len == 2) return name.charAt(0) + "*";
+
+        int visible = Math.min(2, len - 1); // 최대 2글자 노출
+        StringBuilder sb = new StringBuilder();
+        sb.append(name, 0, visible);
+        for (int i = visible; i < len; i++) sb.append('*');
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/example/musinssak/common/util/RatingUtils.java
+++ b/src/main/java/com/example/musinssak/common/util/RatingUtils.java
@@ -1,0 +1,31 @@
+package com.example.musinssak.common.util;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.HashMap;
+import java.util.Map;
+
+/*
+    평균 별점 반올림/분포 보정 유틸
+    DB에서 나온 “원시 집계값”(평균, 별점별 개수)을 API 명세 포맷(소수 첫째 자리 반올림 평균, "5"~"1" 문자열 키의 분포 맵)으로
+    안전하게/일관되게 변환하는 표현 가공 유틸이에요. → 즉, “비즈니스 결과”를 “클라이언트가 보기 좋은 형태”로 바꿀 때 씁니다.
+ */
+public final class RatingUtils {
+
+    private RatingUtils(){}
+
+    /** 소수 첫째 자리 반올림 (예: 4.56 -> 4.6) */
+    public static double round1(double value) {
+        return BigDecimal.valueOf(value).setScale(1, RoundingMode.HALF_UP).doubleValue();
+    }
+
+    /** 분포 맵을 "5"~"1" 키로 모두 채워 반환(누락시 0) */
+    public static Map<String, Integer> fillDistribution(Map<Integer, Integer> raw) {
+        Map<String, Integer> result = new HashMap<>();
+        for (int r = 5; r >= 1; r--) {
+            int count = raw == null ? 0 : raw.getOrDefault(r, 0);
+            result.put(String.valueOf(r), count);
+        }
+        return result;
+    }
+}

--- a/src/main/java/com/example/musinssak/common/util/ReviewSorts.java
+++ b/src/main/java/com/example/musinssak/common/util/ReviewSorts.java
@@ -1,0 +1,46 @@
+package com.example.musinssak.common.util;
+
+import com.example.musinssak.api.review.dto.SortType;
+import org.springframework.data.domain.Sort;
+
+// 정렬 규칙 유틸 (동점 시 최신 우선 포함)
+public final class ReviewSorts {
+
+    private ReviewSorts() {}
+
+    /**
+     * 리뷰 정렬 규칙:
+     * latest: createdAt DESC
+     * high  : rating DESC, createdAt DESC
+     * low   : rating ASC,  createdAt DESC
+     */
+    /** 엔티티 기반(JPQL) 쓸 때만 사용 */
+    public static Sort toJpaSort(SortType sortType) {
+        return switch (sortType) {
+            case LATEST -> Sort.by(Sort.Order.desc("createdAt"));
+            case HIGH   -> Sort.by(
+                    Sort.Order.desc("rating"),
+                    Sort.Order.desc("createdAt")
+            );
+            case LOW    -> Sort.by(
+                    Sort.Order.asc("rating"),
+                    Sort.Order.desc("createdAt")
+            );
+        };
+    }
+
+    /** 네이티브 SQL(테이블 컬럼명)용 정렬 */
+    public static Sort toNativeSort(SortType sortType) {
+        return switch (sortType) {
+            case LATEST -> Sort.by(Sort.Order.desc("created_at"));
+            case HIGH   -> Sort.by(
+                    Sort.Order.desc("rating"),
+                    Sort.Order.desc("created_at")
+            );
+            case LOW    -> Sort.by(
+                    Sort.Order.asc("rating"),
+                    Sort.Order.desc("created_at")
+            );
+        };
+    }
+}

--- a/src/main/java/com/example/musinssak/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/musinssak/domain/product/repository/ProductRepository.java
@@ -19,4 +19,6 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
     // 상품 id로 상품 + 브랜드 조회
     @Query("select p from Product p join fetch p.brand where p.id = :id")
     Optional<Product> findByIdWithBrand(@Param("id") Long id);
+
+    boolean existsById(Long id);
 }

--- a/src/main/java/com/example/musinssak/domain/product/service/ProductQueryService.java
+++ b/src/main/java/com/example/musinssak/domain/product/service/ProductQueryService.java
@@ -3,6 +3,9 @@ package com.example.musinssak.domain.product.service;
 import com.example.musinssak.domain.product.entity.Product;
 import com.example.musinssak.domain.product.entity.ProductImage;
 import com.example.musinssak.domain.product.entity.ProductOption;
+import com.example.musinssak.domain.review.repository.ReviewRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
 
 import java.util.List;
 
@@ -16,4 +19,6 @@ public interface ProductQueryService {
 
     // 옵션(사이즈/재고/가격) 목록 (id ASC)
     List<ProductOption> getOptions(Long productId);
+
+    void assertExists(Long productId);
 }

--- a/src/main/java/com/example/musinssak/domain/product/service/ProductQueryServiceImpl.java
+++ b/src/main/java/com/example/musinssak/domain/product/service/ProductQueryServiceImpl.java
@@ -38,4 +38,12 @@ public class ProductQueryServiceImpl implements ProductQueryService {
     public List<ProductOption> getOptions(Long productId) {
         return productOptionRepository.findAllByProductIdOrderByIdAsc(productId);
     }
+
+    @Override
+    public void assertExists(Long productId) {
+
+        if (productId == null || !productRepository.existsById(productId)) {
+            throw new BusinessException(ErrorCode.PRODUCT_NOT_FOUND);
+        }
+    }
 }

--- a/src/main/java/com/example/musinssak/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/example/musinssak/domain/review/repository/ReviewRepository.java
@@ -1,9 +1,13 @@
 package com.example.musinssak.domain.review.repository;
 
 import com.example.musinssak.domain.review.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
@@ -13,4 +17,47 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     // 리뷰 개수
     long countByProduct_Id(Long productId);
+
+    // 별점 분포 집계 (rating 별 개수 반환)
+    @Query("""
+       select r.rating, count(r.id)
+       from Review r
+       where r.product.id = :productId
+       group by r.rating
+       """)
+    List<Object[]> countGroupByRating(@Param("productId") Long productId);
+
+    // 네이티브 SQL (nativeQuery = true)
+    // - JPQL이 아님 → 실제 DB 테이블/컬럼명을 그대로 사용해야 함
+    // - select 절에서 별칭(alias) ↔ 인터페이스 getter 이름이 매칭됨
+    @Query(value = """
+        select
+            r.id as id,               -- 리뷰 ID (Review PK)
+            r.rating as rating,       -- 리뷰 별점 (1~5)
+            u.nickname as authorName, -- 작성자 닉네임 (users.nickname)
+            (case when exists (
+                select 1 from review_images ri where ri.review_id = r.id
+            ) then 1 else 0 end) as hasPhoto,
+            r.content as content,     -- 리뷰 본문
+            r.created_at as createdAt -- 리뷰 작성일
+        from reviews r
+            join users u on u.id = r.user_id -- 리뷰 작성자 조인
+        where r.product_id = :productId     -- 특정 상품 리뷰만 조회
+        """,
+            countQuery = """
+        select count(*) 
+        from reviews r 
+        where r.product_id = :productId     -- 페이징용 전체 개수
+        """,
+            nativeQuery = true)
+    Page<ReviewListRow> findReviewRowsByProductId(@Param("productId") Long productId, Pageable pageable);
+
+    interface ReviewListRow {
+        Long getId();
+        Integer getRating();
+        String getAuthorName();
+        Number getHasPhoto();    // Boolean → Number 로 변경 (중요), 안전한 타입
+        String getContent();
+        java.time.LocalDateTime getCreatedAt();
+    }
 }

--- a/src/main/java/com/example/musinssak/domain/review/service/ReviewQueryService.java
+++ b/src/main/java/com/example/musinssak/domain/review/service/ReviewQueryService.java
@@ -1,6 +1,20 @@
 package com.example.musinssak.domain.review.service;
 
+import com.example.musinssak.domain.review.repository.ReviewRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
+
+import java.util.Map;
+
 public interface ReviewQueryService {
     Double getAverageRating(Long productId);  // null이면 리뷰 없음
     long getReviewCount(Long productId);
+
+    long getTotalCount(Long productId);
+
+    Double getAverageRatingRaw(Long productId);
+
+    Map<Integer, Integer> getRatingDistribution(Long productId);
+
+    Page<ReviewRepository.ReviewListRow> getReviewPage(Long productId, int zeroBasedPage, int size, Sort sort);
 }

--- a/src/main/java/com/example/musinssak/domain/review/service/ReviewQueryServiceImpl.java
+++ b/src/main/java/com/example/musinssak/domain/review/service/ReviewQueryServiceImpl.java
@@ -2,8 +2,15 @@ package com.example.musinssak.domain.review.service;
 
 import com.example.musinssak.domain.review.repository.ReviewRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @Service
@@ -20,5 +27,34 @@ public class ReviewQueryServiceImpl implements ReviewQueryService {
     @Override
     public long getReviewCount(Long productId) {
         return reviewRepository.countByProduct_Id(productId);
+    }
+
+    @Override
+    public long getTotalCount(Long productId) {
+        // DB에서 해당 상품의 리뷰 총 개수만 카운트 (가볍고 빠름)
+        return reviewRepository.countByProduct_Id(productId);
+    }
+
+    @Override
+    public Double getAverageRatingRaw(Long productId) {
+        // 리뷰가 없으면 null이 올 수 있음 → 파사드에서 0.0 처리 & 반올림
+        return reviewRepository.findAverageRatingByProductId(productId);
+    }
+
+    @Override
+    public Map<Integer, Integer> getRatingDistribution(Long productId) {
+        List<Object[]> buckets = reviewRepository.countGroupByRating(productId);
+        Map<Integer, Integer> result = new HashMap<>();
+        for (Object[] row : buckets) {
+            Integer rating = (Integer) row[0]; // 별점
+            Long cnt = (Long) row[1];          // 개수
+            result.put(rating, cnt.intValue());
+        }
+        return result; // {5=89, 4=25, 3=13 ...}
+    }
+
+    @Override
+    public Page<ReviewRepository.ReviewListRow> getReviewPage(Long productId, int zeroBasedPage, int size, Sort sort) {
+        return reviewRepository.findReviewRowsByProductId(productId, PageRequest.of(zeroBasedPage, size, sort));
     }
 }


### PR DESCRIPTION
[작업한 내용]
- 상품 상세의 리뷰 탭 API 구현 (GET /api/products/{productId}/reviews)
- 페이지네이션 지원(page 1-based, size)
- 정렬 지원: 최신순(latest), 평점 높은순(high), 낮은순(low)
   ↳ 동점 시 최신 우선
- 집계 데이터 제공: 총 리뷰 수, 평균 평점(소수 1자리 반올림), 별점 분포(“5”~“1” 문자열 키, 누락 0 보정)
- 리뷰 목록 DTO 변환: 별점/작성자(마스킹)/포토유무/내용/작성일(yyyy-MM-dd)
- 응답 필드: page(1-based), size, hasNext(Page.hasNext())
- 비로그인 사용자 조회 가능

[참고사항]
- 예외 처리: 상품 미존재 시 404 PRODUCT_NOT_FOUND, 서버 오류 500 INTERNAL_SERVER_ERROR
- 정렬 기본값: latest
- 내부적으로는 page를 0-based로 변환 후 처리, 응답에서 1-based로 복원