### PR TITLE
feat: 상품 문의 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/example/musinssak/api/product/ProductQuestionQueryController.java
+++ b/src/main/java/com/example/musinssak/api/product/ProductQuestionQueryController.java
@@ -1,0 +1,43 @@
+package com.example.musinssak.api.product;
+
+import com.example.musinssak.api.product.dto.GetProductQuestionsRequest;
+import com.example.musinssak.api.product.dto.ProductQuestionResponse;
+import com.example.musinssak.api.product.dto.QuestionSort;
+import com.example.musinssak.api.product.facade.ProductQuestionQueryFacade;
+import com.example.musinssak.common.web.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@Validated
+public class ProductQuestionQueryController {
+
+    private final ProductQuestionQueryFacade productQuestionQueryFacade;
+
+    /**
+     * 상품 상세 페이지 → 문의 탭 클릭 시 호출
+     * 비로그인 사용자도 조회 가능
+     * 정렬: latest(기본), pendingFirst
+     * 페이지: 1-based
+     */
+    @GetMapping("/api/products/{productId}/questions")
+    public ApiResponse<ProductQuestionResponse> getProductQuestions(
+            @PathVariable("productId") Long productId,
+            @Valid @ModelAttribute GetProductQuestionsRequest request
+    ) {
+        // sort 파싱 (null -> LATEST)
+        QuestionSort sort = request.resolveSort();
+
+        ProductQuestionResponse data = productQuestionQueryFacade.getProductQuestions(
+                productId,
+                sort,
+                request.getPage(),
+                request.getSize()
+        );
+
+        return ApiResponse.success("상품 문의 목록을 성공적으로 조회했습니다.", data);
+    }
+}

--- a/src/main/java/com/example/musinssak/api/product/dto/GetProductQuestionsRequest.java
+++ b/src/main/java/com/example/musinssak/api/product/dto/GetProductQuestionsRequest.java
@@ -1,0 +1,30 @@
+// src/main/java/com/example/musinssak/api/product/dto/GetProductQuestionsRequest.java
+package com.example.musinssak.api.product.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter                 // ✅ 추가
+@NoArgsConstructor       // ✅ 추가 (기본 생성자)
+@ToString
+public class GetProductQuestionsRequest {
+
+    private String sort; // latest | pendingFirst (nullable 허용 → 기본값 처리)
+
+    @NotNull
+    @Min(1)
+    private Integer page;
+
+    @NotNull
+    @Min(1)
+    private Integer size;
+
+    public QuestionSort resolveSort() {
+        return QuestionSort.from(sort);
+    }
+}

--- a/src/main/java/com/example/musinssak/api/product/dto/ProductQuestionMapper.java
+++ b/src/main/java/com/example/musinssak/api/product/dto/ProductQuestionMapper.java
@@ -1,0 +1,35 @@
+// src/main/java/com/example/musinssak/api/product/dto/ProductQuestionsMapper.java
+package com.example.musinssak.api.product.dto;
+
+import com.example.musinssak.common.util.DateFormatters;
+import com.example.musinssak.common.util.NameMasker;
+import com.example.musinssak.domain.product.entity.ProductQuestion;
+import com.example.musinssak.domain.product.entity.ProductQuestionAnswer;
+
+
+public final class ProductQuestionMapper {
+    private ProductQuestionMapper() {}
+
+    public static ProductQuestionResponse.QuestionSummary toQuestionSummary(
+            ProductQuestion q,
+            ProductQuestionAnswer answerOrNull
+    ) {
+        var builder = ProductQuestionResponse.QuestionSummary.builder()
+                .id(q.getId())
+                .author(NameMasker.mask(q.getUser().getNickname()))
+                .status(q.getStatus())
+                .question(q.getContent())
+                .questionDate(DateFormatters.toYMD(q.getCreatedAt()));
+
+        if (answerOrNull != null) {
+            builder.answer(
+                    ProductQuestionResponse.AnswerSummary.builder()
+                            .responder(answerOrNull.getResponderType())
+                            .content(answerOrNull.getContent())
+                            .answerDate(DateFormatters.toYMD(answerOrNull.getAnsweredAt()))
+                            .build()
+            );
+        }
+        return builder.build();
+    }
+}

--- a/src/main/java/com/example/musinssak/api/product/dto/ProductQuestionResponse.java
+++ b/src/main/java/com/example/musinssak/api/product/dto/ProductQuestionResponse.java
@@ -1,0 +1,44 @@
+package com.example.musinssak.api.product.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductQuestionResponse {
+    private Long productId;
+    private int totalQuestions;
+    private List<QuestionSummary> questions;
+    private int page;    // 1-based
+    private int size;
+    private boolean hasNext;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class QuestionSummary {
+        private Long id;
+        private String author;       // 마스킹된 닉네임 (예: 박**)
+        private String status;       // PENDING | ANSWERED
+        private String question;     // 문의 내용(content)
+        private String questionDate; // yyyy-MM-dd
+
+        @JsonInclude(JsonInclude.Include.NON_NULL)
+        private AnswerSummary answer; // 선택적
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AnswerSummary {
+        private String responder;   // SELLER | ADMIN 등
+        private String content;
+        private String answerDate;  // yyyy-MM-dd
+    }
+}

--- a/src/main/java/com/example/musinssak/api/product/dto/QuestionSort.java
+++ b/src/main/java/com/example/musinssak/api/product/dto/QuestionSort.java
@@ -1,0 +1,25 @@
+package com.example.musinssak.api.product.dto;
+
+import com.example.musinssak.domain.product.service.QuestionSortOption;
+
+public enum QuestionSort {
+    LATEST,
+    PENDING_FIRST;
+
+    public static QuestionSort from(String raw) {
+        if (raw == null) return LATEST;
+        String v = raw.trim().toLowerCase();
+        return switch (v) {
+            case "latest" -> LATEST;
+            case "pendingfirst" -> PENDING_FIRST;
+            default -> LATEST;
+        };
+    }
+
+    public QuestionSortOption toDomain() {
+        return switch (this) {
+            case LATEST -> QuestionSortOption.LATEST;
+            case PENDING_FIRST -> QuestionSortOption.PENDING_FIRST;
+        };
+    }
+}

--- a/src/main/java/com/example/musinssak/api/product/facade/ProductQuestionQueryFacade.java
+++ b/src/main/java/com/example/musinssak/api/product/facade/ProductQuestionQueryFacade.java
@@ -1,0 +1,8 @@
+package com.example.musinssak.api.product.facade;
+
+import com.example.musinssak.api.product.dto.ProductQuestionResponse;
+import com.example.musinssak.api.product.dto.QuestionSort;
+
+public interface ProductQuestionQueryFacade {
+    ProductQuestionResponse getProductQuestions(Long productId, QuestionSort sort, int page, int size);
+}

--- a/src/main/java/com/example/musinssak/api/product/facade/ProductQuestionQueryFacadeImpl.java
+++ b/src/main/java/com/example/musinssak/api/product/facade/ProductQuestionQueryFacadeImpl.java
@@ -1,0 +1,58 @@
+package com.example.musinssak.api.product.facade;
+
+import com.example.musinssak.api.product.dto.ProductQuestionMapper;
+import com.example.musinssak.api.product.dto.ProductQuestionResponse;
+import com.example.musinssak.api.product.dto.QuestionSort;
+import com.example.musinssak.domain.product.entity.ProductQuestion;
+import com.example.musinssak.domain.product.entity.ProductQuestionAnswer;
+import com.example.musinssak.domain.product.service.ProductQuestionAnswerQueryService;
+import com.example.musinssak.domain.product.service.ProductQuestionQueryService;
+import com.example.musinssak.domain.product.service.ProductReaderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProductQuestionQueryFacadeImpl implements ProductQuestionQueryFacade {
+
+    private final ProductReaderService productReaderService;
+    private final ProductQuestionQueryService productQuestionQueryService;
+    private final ProductQuestionAnswerQueryService answerQueryService;
+
+    @Override
+    public ProductQuestionResponse getProductQuestions(Long productId, QuestionSort sort, int page, int size) {
+        // 1) 상품 존재 검증 (없으면 BusinessException(PRODUCT_NOT_FOUND) 발생)
+        productReaderService.getByIdOrThrow(productId);
+
+        // 2) 문의 페이지 조회 (정렬/페이징은 서비스가 처리)
+        Page<ProductQuestion> questionPage =
+                productQuestionQueryService.getQuestionsPage(productId, sort.toDomain(), page, size);
+
+        // 3) 답변 일괄 조회 (N+1 방지)
+        List<Long> questionIds = questionPage.getContent().stream()
+                .map(ProductQuestion::getId)
+                .toList();
+        Map<Long, ProductQuestionAnswer> answerMap = answerQueryService.findByQuestionIds(questionIds);
+
+        // 4) 엔티티 -> API DTO 매핑 (닉네임 마스킹/날짜 포맷 내부 적용)
+        List<ProductQuestionResponse.QuestionSummary> questionDtos = questionPage.getContent().stream()
+                .map(q -> ProductQuestionMapper.toQuestionSummary(q, answerMap.get(q.getId())))
+                .toList();
+
+        // 5) 응답 조립 (total은 Page의 totalElements 사용 → count 쿼리 이미 실행됨)
+        return ProductQuestionResponse.builder()
+                .productId(productId)
+                .totalQuestions((int) questionPage.getTotalElements())
+                .questions(questionDtos)
+                .page(page)              // 1-based 그대로
+                .size(size)
+                .hasNext(questionPage.hasNext())
+                .build();
+    }
+}

--- a/src/main/java/com/example/musinssak/domain/product/entity/ProductQuestion.java
+++ b/src/main/java/com/example/musinssak/domain/product/entity/ProductQuestion.java
@@ -1,0 +1,50 @@
+package com.example.musinssak.domain.product.entity;
+
+import com.example.musinssak.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "product_questions")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductQuestion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 작성자 (User 연관관계)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 상품 (Product 연관관계)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+
+    // 문의 유형 (예: 배송, 상품상세, 재입고 등)
+    @Column(length = 50)
+    private String type;
+
+    // 문의 제목
+    @Column()
+    private String title;
+
+    // 문의 내용
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    // 상태 (예: PENDING, ANSWERED)
+    @Column(length = 50)
+    private String status;
+
+    // 작성일
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/example/musinssak/domain/product/entity/ProductQuestionAnswer.java
+++ b/src/main/java/com/example/musinssak/domain/product/entity/ProductQuestionAnswer.java
@@ -1,0 +1,35 @@
+// src/main/java/com/example/musinssak/domain/product/entity/ProductQuestionAnswer.java
+package com.example.musinssak.domain.product.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "product_question_answers")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductQuestionAnswer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 질문 1개 : 답변 1개 (DB에서 question_id UNIQUE + NOT NULL과 일치)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false, unique = true)
+    private ProductQuestion question;
+
+    // SELLER, ADMIN 등
+    @Column(name = "responder_type", length = 50)
+    private String responderType;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    @Column(name = "answered_at")
+    private LocalDateTime answeredAt;
+}

--- a/src/main/java/com/example/musinssak/domain/product/repository/ProductQuestionAnswerRepository.java
+++ b/src/main/java/com/example/musinssak/domain/product/repository/ProductQuestionAnswerRepository.java
@@ -1,0 +1,17 @@
+package com.example.musinssak.domain.product.repository;
+
+import com.example.musinssak.domain.product.entity.ProductQuestionAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductQuestionAnswerRepository extends JpaRepository<ProductQuestionAnswer, Long> {
+
+    // 질문 1개 : 답변 1개 구조 → 단건 조회
+    Optional<ProductQuestionAnswer> findByQuestionId(Long questionId);
+
+    // 페이지 조회 시 N+1 방지를 위한 일괄 조회
+    List<ProductQuestionAnswer> findByQuestionIdIn(Collection<Long> questionIds);
+}

--- a/src/main/java/com/example/musinssak/domain/product/repository/ProductQuestionRepository.java
+++ b/src/main/java/com/example/musinssak/domain/product/repository/ProductQuestionRepository.java
@@ -1,0 +1,31 @@
+package com.example.musinssak.domain.product.repository;
+
+import com.example.musinssak.domain.product.entity.ProductQuestion;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ProductQuestionRepository extends JpaRepository<ProductQuestion, Long> {
+
+    long countByProductId(Long productId);
+
+    // 최신순
+    @Query(
+            value = "SELECT q FROM ProductQuestion q " +
+                    "WHERE q.product.id = :productId " +
+                    "ORDER BY q.createdAt DESC",
+            countQuery = "SELECT COUNT(q) FROM ProductQuestion q WHERE q.product.id = :productId"
+    )
+    Page<ProductQuestion> findLatestByProductId(@Param("productId") Long productId, Pageable pageable);
+
+    // 답변대기 우선순 (PENDING 먼저, 그 다음 최신순)
+    @Query(
+            value = "SELECT q FROM ProductQuestion q " +
+                    "WHERE q.product.id = :productId " +
+                    "ORDER BY CASE WHEN q.status = 'PENDING' THEN 0 ELSE 1 END, q.createdAt DESC",
+            countQuery = "SELECT COUNT(q) FROM ProductQuestion q WHERE q.product.id = :productId"
+    )
+    Page<ProductQuestion> findPendingFirstByProductId(@Param("productId") Long productId, Pageable pageable);
+}

--- a/src/main/java/com/example/musinssak/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/example/musinssak/domain/product/repository/ProductRepository.java
@@ -1,6 +1,7 @@
 package com.example.musinssak.domain.product.repository;
 
 import com.example.musinssak.domain.product.entity.Product;
+import lombok.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -20,5 +21,5 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
     @Query("select p from Product p join fetch p.brand where p.id = :id")
     Optional<Product> findByIdWithBrand(@Param("id") Long id);
 
-    boolean existsById(Long id);
+    boolean existsById(@NonNull Long id);
 }

--- a/src/main/java/com/example/musinssak/domain/product/service/ProductQuestionAnswerQueryService.java
+++ b/src/main/java/com/example/musinssak/domain/product/service/ProductQuestionAnswerQueryService.java
@@ -1,0 +1,10 @@
+package com.example.musinssak.domain.product.service;
+
+import com.example.musinssak.domain.product.entity.ProductQuestionAnswer;
+
+import java.util.Collection;
+import java.util.Map;
+
+public interface ProductQuestionAnswerQueryService {
+    Map<Long, ProductQuestionAnswer> findByQuestionIds(Collection<Long> questionIds);
+}

--- a/src/main/java/com/example/musinssak/domain/product/service/ProductQuestionAnswerQueryServiceImpl.java
+++ b/src/main/java/com/example/musinssak/domain/product/service/ProductQuestionAnswerQueryServiceImpl.java
@@ -1,0 +1,31 @@
+package com.example.musinssak.domain.product.service;
+
+import com.example.musinssak.domain.product.entity.ProductQuestionAnswer;
+import com.example.musinssak.domain.product.repository.ProductQuestionAnswerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProductQuestionAnswerQueryServiceImpl implements ProductQuestionAnswerQueryService {
+
+    private final ProductQuestionAnswerRepository answerRepository;
+
+    @Override
+    public Map<Long, ProductQuestionAnswer> findByQuestionIds(Collection<Long> questionIds) {
+        if (questionIds == null || questionIds.isEmpty()) return Map.of();
+
+        return answerRepository.findByQuestionIdIn(questionIds).stream()
+                .collect(Collectors.toMap(
+                        a -> a.getQuestion().getId(),
+                        Function.identity()
+                ));
+    }
+}

--- a/src/main/java/com/example/musinssak/domain/product/service/ProductQuestionQueryService.java
+++ b/src/main/java/com/example/musinssak/domain/product/service/ProductQuestionQueryService.java
@@ -1,0 +1,8 @@
+package com.example.musinssak.domain.product.service;
+
+import com.example.musinssak.domain.product.entity.ProductQuestion;
+import org.springframework.data.domain.Page;
+
+public interface ProductQuestionQueryService {
+    Page<ProductQuestion> getQuestionsPage(Long productId, QuestionSortOption sort, int page, int size);
+}

--- a/src/main/java/com/example/musinssak/domain/product/service/ProductQuestionQueryServiceImpl.java
+++ b/src/main/java/com/example/musinssak/domain/product/service/ProductQuestionQueryServiceImpl.java
@@ -1,0 +1,29 @@
+package com.example.musinssak.domain.product.service;
+
+import com.example.musinssak.domain.product.entity.ProductQuestion;
+import com.example.musinssak.domain.product.repository.ProductQuestionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProductQuestionQueryServiceImpl implements ProductQuestionQueryService {
+
+    private final ProductQuestionRepository productQuestionRepository;
+
+    @Override
+    public Page<ProductQuestion> getQuestionsPage(Long productId, QuestionSortOption sort, int page, int size) {
+        // API는 1-based, JPA는 0-based → 여기서 변환(추후 공통 유틸로 이동 가능)
+        int pageIndex = Math.max(page - 1, 0);
+        PageRequest pageable = PageRequest.of(pageIndex, size);
+
+        return switch (sort) {
+            case PENDING_FIRST -> productQuestionRepository.findPendingFirstByProductId(productId, pageable);
+            case LATEST -> productQuestionRepository.findLatestByProductId(productId, pageable);
+        };
+    }
+}

--- a/src/main/java/com/example/musinssak/domain/product/service/ProductReaderService.java
+++ b/src/main/java/com/example/musinssak/domain/product/service/ProductReaderService.java
@@ -1,0 +1,6 @@
+package com.example.musinssak.domain.product.service;
+
+public interface ProductReaderService {
+    void getByIdOrThrow(Long productId);
+    boolean exists(Long productId); // 상품 존재 여부만 boolean 으로 확인할 수 있는 exists(productId) 메서드 구현
+}

--- a/src/main/java/com/example/musinssak/domain/product/service/ProductReaderServiceImpl.java
+++ b/src/main/java/com/example/musinssak/domain/product/service/ProductReaderServiceImpl.java
@@ -1,0 +1,27 @@
+package com.example.musinssak.domain.product.service;
+
+import com.example.musinssak.domain.product.repository.ProductRepository;
+import com.example.musinssak.common.exception.BusinessException;
+import com.example.musinssak.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProductReaderServiceImpl implements ProductReaderService {
+
+    private final ProductRepository productRepository;
+
+    @Override
+    public void getByIdOrThrow(Long productId) {
+        productRepository.findById(productId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+    }
+
+    @Override
+    public boolean exists(Long productId) {
+        return productRepository.existsById(productId);
+    }
+}

--- a/src/main/java/com/example/musinssak/domain/product/service/QuestionSortOption.java
+++ b/src/main/java/com/example/musinssak/domain/product/service/QuestionSortOption.java
@@ -1,0 +1,15 @@
+package com.example.musinssak.domain.product.service;
+
+public enum QuestionSortOption {
+    LATEST,        // 최신순
+    PENDING_FIRST; // 답변대기 우선
+
+    public static QuestionSortOption from(String value) {
+        if (value == null) return LATEST;
+        return switch (value.toLowerCase()) {
+            case "latest" -> LATEST;
+            case "pendingfirst" -> PENDING_FIRST;
+            default -> LATEST;
+        };
+    }
+}

--- a/src/main/resources/db/migration/V14__enforce_one_answer_per_question.sql
+++ b/src/main/resources/db/migration/V14__enforce_one_answer_per_question.sql
@@ -1,0 +1,12 @@
+-- 목적: product_questions : product_question_answers 를 1:1로 강제하기 위해
+--       question_id 에 UNIQUE 제약과 NOT NULL 제약을 추가
+-- 이유: 질문당 답변은 무조건 1개라는 도메인 규칙을 DB 레벨에서 보장하고,
+--       JPA @OneToOne(unique = true) 와 스키마를 일치시키기 위함.
+
+-- 1) question_id는 반드시 존재해야 함 (NULL 금지)
+ALTER TABLE product_question_answers
+    MODIFY question_id BIGINT NOT NULL;
+
+-- 2) 질문 1개당 답변 1개만 가능하도록 UNIQUE 제약 추가
+ALTER TABLE product_question_answers
+    ADD CONSTRAINT uq_product_question_answers_question_id UNIQUE (question_id);


### PR DESCRIPTION
[작업한 내용]
- 상품 문의 목록 조회 API (GET /api/products/{productId}/questions) 구현
- ProductQuestionAnswer 엔티티 및 레포지토리 추가
- ProductQuestionRepository 정렬 쿼리(최신순, 답변대기 우선) 구현
- 서비스 계층 분리 (상품 검증 / 문의 조회 / 답변 일괄 조회)
- 파사드 조립 구현 (상품 검증 → 문의 페이지 조회 → 답변 조회 → DTO 매핑)
- API DTO/매퍼/컨트롤러 작성
- 닉네임 마스킹, 날짜 포맷 등 응답 규격 적용
- DB 마이그레이션(V14)로 question_id NOT NULL + UNIQUE 제약 추가
- DTO 바인딩 오류 수정 (GetProductQuestionsRequest 기본 생성자 + setter 추가)
- IDE 경고 제거 (@NonNull 적용)

[참고사항]
- 현재 API는 조회 전용이며, 작성/수정 API는 포함되지 않았습니다.
- ProductReaderService.exists() 메서드는 구현되어 있으나, 현재 API에서는 사용하지 않았습니다.
- 글로벌 예외/응답 래퍼(ApiResponse, ErrorCode)는 기존 common 모듈의 것을 재사용했습니다.
- 프론트엔드에서 sort 기본값이 누락되면 자동으로 latest로 처리됩니다.