### PR TITLE
feat: Prometheus + Grafana 모니터링 스택 도입 및 Actuator 지표 노출

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -1,5 +1,8 @@
 server:
   port: 8080
+  tomcat:
+    mbeanregistry:
+      enabled: true   # ← Tomcat 스레드/세션 지표가 생성되도록 MBean 등록
 
 spring:
   flyway: # Flyway 활성화
@@ -86,3 +89,34 @@ kakao:
   local:
     base-url: https://dapi.kakao.com
     rest-api-key: ${KAKAO_REST_API_KEY}
+
+# 개발 모니터링 (운영: 서비스는 8080 유지, Actuator만 8081로 분리)
+management:
+  endpoints:
+    web:
+      exposure:
+        include: [health, info, prometheus]   # 리스트 형태 권장
+  endpoint:
+    health:
+      show-details: "always"
+
+  metrics:
+    enable:
+      tomcat: true        # ← 톰캣 메트릭 바인더 활성화(보통 기본 true지만 명시 권장)
+    tags:
+      application: ${spring.application.name}
+    distribution:
+      percentiles-histogram:
+        http:
+          server:
+            requests: true      # 히스토그램 ON (HTTP 서버)
+      slo:
+        http:
+          server:
+            # 소수초(0.1s, 0.3s ...) 대신 정수 Duration 사용
+            requests: [ 100ms, 300ms, 500ms, 1s, 3s ]
+  prometheus:
+    metrics:
+      export:
+        enabled: true
+

--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,12 @@ dependencies {
     implementation 'javax.annotation:javax.annotation-api:1.3.2'
     // 비밀번호 찾기 이메일 기능
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+
+    // 모니터링 관리/지표 엔드포인트 제공
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+    // 모니터링 Prometheus 포맷 출력
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 }
 
 tasks.named('test') {

--- a/infra/monitoring/docker-compose.monitoring.yml
+++ b/infra/monitoring/docker-compose.monitoring.yml
@@ -1,0 +1,22 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: musinsa-prometheus
+    volumes:
+      - ./infra/monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro # root경로 기준
+#      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"   # Prometheus UI
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: musinsa-grafana
+    ports:
+      - "3000:3000"   # Grafana UI
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    depends_on:
+      - prometheus
+    restart: unless-stopped

--- a/infra/monitoring/prometheus.yml
+++ b/infra/monitoring/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: "spring-boot"
+    metrics_path: "/actuator/prometheus"
+    static_configs:
+      - targets: ["host.docker.internal:8080"]
+        # Windows/Mac Docker Desktop: host.docker.internal
+        # 리눅스 네이티브 Docker면 172.17.0.1 또는 실제 호스트 IP로 교체

--- a/src/main/java/com/example/musinssak/infra/security/SecurityConfig.java
+++ b/src/main/java/com/example/musinssak/infra/security/SecurityConfig.java
@@ -95,6 +95,9 @@ public class SecurityConfig {
                         // 주문
                         .requestMatchers("/api/orders/**").authenticated()
 
+                        // 모니터링
+                        .requestMatchers("/actuator/health", "/actuator/prometheus").permitAll()
+
                         /* ---------- ③ 그 외 ---------- */
                         .anyRequest().permitAll() // 개발 단계: 나머지는 공개. 필요 시 authenticated()로 전환
                 )


### PR DESCRIPTION
[작업한 내용]
- Feat: Actuator 노출 및 Micrometer 지표 설정(히스토그램·SLO·Tomcat MBean·태그)
- Feat: Security에서 /actuator/health, /actuator/prometheus permitAll
- Chore: Prometheus/Grafana compose 추가
- Chore: Prometheus 스크레이프 설정 추가
- Chore: Actuator/Micrometer Prometheus 의존성 추가

[참고사항]
1. 변경 배경
- 커스텀 지표/대시보드 구성 및 로컬·CI/CD 분리 기동을 위해 Prometheus + Grafana 체계 도입
- 부하 테스트 전 지표 수집 파이프라인 선 구축

2. 실행 방법
- 코어 + 모니터링 기동
```bash
docker compose -f docker-compose.yml -f infra/monitoring/docker-compose.monitoring.yml up -d
```
- 애플리케이션 기동
```bash
./gradlew clean bootRun
```
3. 검증 체크리스트
- http://localhost:8080/actuator 노출
- http://localhost:8080/actuator/prometheus 에서 http_server_requests_*, tomcat_threads_*, hikaricp_* 보임
- Prometheus Targets(http://localhost:9090/targets)에서 spring-boot가 UP
- Grafana → Data sources → Prometheus URL http://prometheus:9090 저장 후 쿼리 동작

4. 영향도
- 비즈니스 로직 변경 없음(설정/인프라 추가만)