### PR TITLE
feat: 사용자 쿠폰 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/example/musinssak/api/coupon/CouponBoxController.java
+++ b/src/main/java/com/example/musinssak/api/coupon/CouponBoxController.java
@@ -1,0 +1,38 @@
+package com.example.musinssak.api.coupon;
+
+import com.example.musinssak.api.coupon.dto.UserCouponsResponse;
+import com.example.musinssak.api.coupon.facade.CouponBoxFacade;
+import com.example.musinssak.common.web.ApiResponse;
+import com.example.musinssak.infra.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * (쿠폰함) 사용자 쿠폰 목록
+ * GET /api/users/me/coupons
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class CouponBoxController {
+
+    private final CouponBoxFacade couponBoxFacade;     // 다음 단계에서 구현
+    private final JwtTokenProvider jwtTokenProvider;   // 기존 방식 그대로 사용
+
+    @GetMapping("/me/coupons")
+    public ApiResponse<UserCouponsResponse> getMyCoupons(
+            @RequestHeader("Authorization") String authorizationHeader
+    ) {
+        String token = authorizationHeader.replace("Bearer ", "").trim();
+        Long userId = Long.parseLong(jwtTokenProvider.getSubject(token));
+
+        UserCouponsResponse data = couponBoxFacade.getMyCoupons(userId);
+
+        return ApiResponse.success("사용자 쿠폰 목록이 성공적으로 조회되었습니다.", data);
+    }
+}

--- a/src/main/java/com/example/musinssak/api/coupon/dto/UserCouponResponse.java
+++ b/src/main/java/com/example/musinssak/api/coupon/dto/UserCouponResponse.java
@@ -1,0 +1,28 @@
+package com.example.musinssak.api.coupon.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 사용자 쿠폰 응답 DTO (단일 쿠폰)
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserCouponResponse {
+    private Long couponId;
+    private String couponName;
+    private String couponDescription;
+    private String couponType;         // "PERCENT" | "AMOUNT" | "FREE_DELIVERY"
+    private Integer discountRate;      // 퍼센트 할인율 (nullable)
+    private Integer discountAmount;    // 정액 할인 금액 (nullable)
+    private Integer minOrderPrice;
+    private Integer maxDiscountAmount; // 최대 할인 한도 (nullable)
+    private LocalDateTime expiredAt;
+    private boolean isExpiringSoon;
+}

--- a/src/main/java/com/example/musinssak/api/coupon/dto/UserCouponsResponse.java
+++ b/src/main/java/com/example/musinssak/api/coupon/dto/UserCouponsResponse.java
@@ -1,0 +1,17 @@
+package com.example.musinssak.api.coupon.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 사용자 쿠폰 목록 응답 DTO (상위 래퍼)
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserCouponsResponse {
+    private List<UserCouponResponse> coupons;
+}

--- a/src/main/java/com/example/musinssak/api/coupon/facade/CouponBoxFacade.java
+++ b/src/main/java/com/example/musinssak/api/coupon/facade/CouponBoxFacade.java
@@ -1,0 +1,7 @@
+package com.example.musinssak.api.coupon.facade;
+
+import com.example.musinssak.api.coupon.dto.UserCouponsResponse;
+
+public interface CouponBoxFacade {
+    UserCouponsResponse getMyCoupons(Long userId);
+}

--- a/src/main/java/com/example/musinssak/api/coupon/facade/CouponBoxFacadeImpl.java
+++ b/src/main/java/com/example/musinssak/api/coupon/facade/CouponBoxFacadeImpl.java
@@ -1,0 +1,75 @@
+package com.example.musinssak.api.coupon.facade;
+
+import com.example.musinssak.api.coupon.dto.UserCouponResponse;
+import com.example.musinssak.api.coupon.dto.UserCouponsResponse;
+import com.example.musinssak.api.coupon.facade.CouponBoxFacade;
+import com.example.musinssak.domain.coupon.readmodel.UserCouponRead;
+import com.example.musinssak.domain.coupon.service.UserCouponQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class CouponBoxFacadeImpl implements CouponBoxFacade {
+
+    private final UserCouponQueryService userCouponQueryService;
+
+    @Override
+    public UserCouponsResponse getMyCoupons(Long userId) {
+        LocalDateTime now = LocalDateTime.now();
+
+        // 1) 유효 쿠폰 조회
+        List<UserCouponRead> reads = userCouponQueryService.findActiveCouponsByUserId(userId, now);
+
+        // 2) ReadModel -> DTO 매핑 (+ isExpiringSoon 계산)
+        List<UserCouponResponse> items = reads.stream()
+                .map(r -> UserCouponResponse.builder()
+                        .couponId(r.getCouponId())
+                        .couponName(r.getCouponName())
+                        .couponDescription(r.getCouponDescription())
+                        .couponType(r.getCouponType().name()) // enum -> String
+                        .discountRate(r.getDiscountRate())
+                        .discountAmount(r.getDiscountAmount())
+                        .minOrderPrice(r.getMinOrderPrice())
+                        .maxDiscountAmount(r.getMaxDiscountAmount())
+                        .expiredAt(r.getExpiredAt())
+                        .isExpiringSoon(isExpiringSoon(r.getExpiredAt(), now))
+                        .build())
+                .toList();
+
+        // 3) 정렬: 임박(true 먼저) → 만료일 오름차순(더 빨리 만료되는 것 먼저) → 할인율(PERCENT만) 내림차순 → 이름 오름차순
+        items = items.stream()
+                .sorted(Comparator
+                        // 1) 임박(true) 먼저
+                        .comparing(UserCouponResponse::isExpiringSoon, Comparator.reverseOrder())
+                        // 2) 만료일 오름차순 (null 안전 처리: null은 가장 뒤로)
+                        .thenComparing(UserCouponResponse::getExpiredAt,
+                                Comparator.nullsLast(LocalDateTime::compareTo))
+                        // .thenComparing(UserCouponResponse::getExpiredAt)
+                        // 3) 퍼센트 쿠폰의 할인율 내림차순 (AMOUNT는 0으로 취급)
+                        .thenComparing(r -> "PERCENT".equals(r.getCouponType())
+                                        ? (r.getDiscountRate() != null ? r.getDiscountRate() : 0)
+                                        : 0,
+                                Comparator.reverseOrder())
+                        // 4) 이름 오름차순
+                        .thenComparing(UserCouponResponse::getCouponName,
+                                Comparator.nullsLast(String::compareTo)))
+                .toList();
+
+        // 4) 래핑 후 반환
+        return new UserCouponsResponse(items);
+    }
+
+    // 만료 임박(3일 이하) 판단
+    private boolean isExpiringSoon(LocalDateTime expiredAt, LocalDateTime now) {
+        if (expiredAt == null) return false;        // 만료일 없음 → 임박 아님
+        if (expiredAt.isBefore(now)) return false;  // 이미 만료 → 임박 아님
+        long days = Duration.between(now, expiredAt).toDays(); // now 기준 남은 일수
+        return days <= 3; // 오늘 포함 3일 이하면 true
+    }
+}

--- a/src/main/java/com/example/musinssak/domain/coupon/entity/Coupon.java
+++ b/src/main/java/com/example/musinssak/domain/coupon/entity/Coupon.java
@@ -1,0 +1,44 @@
+package com.example.musinssak.domain.coupon.entity;
+
+import com.example.musinssak.domain.coupon.type.CouponType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "coupons")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Coupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", length = 50)
+    private CouponType type;
+
+    @Column(name = "discount_rate")
+    private Integer discountRate;       // nullable
+
+    @Column(name = "discount_amount")
+    private Integer discountAmount;     // nullable
+
+    @Column(name = "min_order_price")
+    private Integer minOrderPrice;
+
+    @Column(name = "max_discount_amount")
+    private Integer maxDiscountAmount;  // nullable
+
+    @Column(name = "expired_at")
+    private LocalDateTime expiredAt;
+}

--- a/src/main/java/com/example/musinssak/domain/coupon/entity/UserCoupon.java
+++ b/src/main/java/com/example/musinssak/domain/coupon/entity/UserCoupon.java
@@ -1,0 +1,37 @@
+package com.example.musinssak.domain.coupon.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_coupons")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserCoupon {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 팀 원칙: User 엔티티 직접참조 X → userId만 보관
+    @Column(name = "user_id")
+    private Long userId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "coupon_id")
+    private Coupon coupon;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    /**
+     * DB에 is_expiring_soon 컬럼이 존재하지만,
+     * - 만료일(expiredAt) 기반으로 "현재 시점(now)"에 따라 달라지는 파생 값
+     * - API 응답 시점에만 계산해야 정확성 유지 가능
+     * → 엔티티 필드에는 매핑하지 않음
+     */
+}

--- a/src/main/java/com/example/musinssak/domain/coupon/readmodel/UserCouponRead.java
+++ b/src/main/java/com/example/musinssak/domain/coupon/readmodel/UserCouponRead.java
@@ -1,0 +1,47 @@
+package com.example.musinssak.domain.coupon.readmodel;
+
+import com.example.musinssak.domain.coupon.type.CouponType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 도메인 레이어의 조회 전용 모델 (ReadModel, Projection)
+ * - Repository/Service → Facade로 전달할 때 사용
+ * - API DTO(UserCouponResponse)와는 별도의 책임
+ */
+@Getter
+@NoArgsConstructor
+public class UserCouponRead {
+
+    private Long couponId;
+    private String couponName;
+    private String couponDescription;
+    private CouponType couponType;     // enum (PERCENT, AMOUNT, FREE_DELIVERY)
+    private Integer discountRate;      // nullable
+    private Integer discountAmount;    // nullable
+    private Integer minOrderPrice;
+    private Integer maxDiscountAmount; // nullable
+    private LocalDateTime expiredAt;
+
+    public UserCouponRead(Long couponId,
+              String couponName,
+              String couponDescription,
+              CouponType couponType,
+              Integer discountRate,
+              Integer discountAmount,
+              Integer minOrderPrice,
+              Integer maxDiscountAmount,
+              LocalDateTime expiredAt) {
+        this.couponId = couponId;
+        this.couponName = couponName;
+        this.couponDescription = couponDescription;
+        this.couponType = couponType;
+        this.discountRate = discountRate;
+        this.discountAmount = discountAmount;
+        this.minOrderPrice = minOrderPrice;
+        this.maxDiscountAmount = maxDiscountAmount;
+        this.expiredAt = expiredAt;
+    }
+}

--- a/src/main/java/com/example/musinssak/domain/coupon/repository/UserCouponRepository.java
+++ b/src/main/java/com/example/musinssak/domain/coupon/repository/UserCouponRepository.java
@@ -1,0 +1,39 @@
+package com.example.musinssak.domain.coupon.repository;
+
+import com.example.musinssak.domain.coupon.entity.UserCoupon;
+import com.example.musinssak.domain.coupon.readmodel.UserCouponRead;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
+
+    /**
+     * 사용자 보유 "유효" 쿠폰만 조회 (만료 제외)
+     * - 만료 조건: c.expiredAt >= :now
+     * - 엔티티 노출 대신 UserCouponRead 생성자 프로젝션으로 반환
+     * - JOIN: user_coupons(uc) ↔ coupons(c)
+     */
+    @Query("""
+        select new com.example.musinssak.domain.coupon.readmodel.UserCouponRead(
+            c.id,
+            c.name,
+            c.description,
+            c.type,
+            c.discountRate,
+            c.discountAmount,
+            c.minOrderPrice,
+            c.maxDiscountAmount,
+            c.expiredAt
+        )
+        from UserCoupon uc
+        join uc.coupon c
+        where uc.userId = :userId
+          and c.expiredAt >= :now
+    """)
+    List<UserCouponRead> findActiveByUserId(@Param("userId") Long userId,
+                                            @Param("now") LocalDateTime now);
+}

--- a/src/main/java/com/example/musinssak/domain/coupon/service/UserCouponQueryService.java
+++ b/src/main/java/com/example/musinssak/domain/coupon/service/UserCouponQueryService.java
@@ -1,0 +1,10 @@
+package com.example.musinssak.domain.coupon.service;
+
+import com.example.musinssak.domain.coupon.readmodel.UserCouponRead;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface UserCouponQueryService {
+    List<UserCouponRead> findActiveCouponsByUserId(Long userId, LocalDateTime now);
+}

--- a/src/main/java/com/example/musinssak/domain/coupon/service/UserCouponQueryServiceImpl.java
+++ b/src/main/java/com/example/musinssak/domain/coupon/service/UserCouponQueryServiceImpl.java
@@ -1,0 +1,23 @@
+package com.example.musinssak.domain.coupon.service;
+
+import com.example.musinssak.domain.coupon.readmodel.UserCouponRead;
+import com.example.musinssak.domain.coupon.repository.UserCouponRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true) // 조회 최적화
+public class UserCouponQueryServiceImpl implements UserCouponQueryService {
+    private final UserCouponRepository userCouponRepository;
+
+    @Override
+    public List<UserCouponRead> findActiveCouponsByUserId(Long userId, LocalDateTime now) {
+        // 만료 제외 로직은 레포지토리 JPQL에서 처리(c.expiredAt >= :now)
+        return userCouponRepository.findActiveByUserId(userId, now);
+    }
+}

--- a/src/main/java/com/example/musinssak/domain/coupon/type/CouponType.java
+++ b/src/main/java/com/example/musinssak/domain/coupon/type/CouponType.java
@@ -1,0 +1,13 @@
+package com.example.musinssak.domain.coupon.type;
+
+/**
+ * 쿠폰 타입
+ * - PERCENT : % 할인
+ * - AMOUNT : 정액 할인
+ * - FREE_DELIVERY : 무료 배송
+ */
+public enum CouponType {
+    PERCENT,
+    AMOUNT,
+    FREE_DELIVERY
+}


### PR DESCRIPTION
[작업한 내용]
- 사용자 쿠폰 목록 조회 API (GET /api/users/me/coupons) 구현
- domain/coupon 에 readmodel, type 패키지 도입
- UserCouponQueryService / CouponBoxFacade 분리 (조회 로직 책임 분리)
- UserCouponRead(ReadModel) 기반 조회 → DTO 매핑
- isExpiringSoon(만료 3일 이내) 계산을 파사드에서 처리
    - DB is_expiring_soon 컬럼은 엔티티에 매핑하지 않고 무시
- 정렬 규칙 적용
  (임박 쿠폰 우선 → 만료일 오름차순 → 퍼센트 할인율 내림차순 → 이름 오름차순)
- API DTO/컨트롤러 작성 (UserCouponsResponse, UserCouponResponse)
- Repository 쿼리: 유효 쿠폰만 조회 (expiredAt >= now)
- LocalDateTime 기반 만료 여부/임박 여부 계산 로직 추가
- 불필요한 엔티티 컬럼 매핑 제거, 응답 일관성 확보

[참고사항]
- 쿠폰 만료 여부는 DB에서 필터링(c.expiredAt >= now), 임박 여부는 파사드에서 계산
- is_expiring_soon 칼럼은 DB에 존재하나 파생값이므로 엔티티에 포함하지 않음
- UX를 고려하여 기본 정렬(임박순 → 만료일 → 할인율 → 이름) 적용
- 추후 쿠폰 사용/발급 API는 별도 구현 예정
