### PR TITLE
feat: 적립금 내역 조회 API 구현

### DIFF
--- a/src/main/java/com/example/musinssak/api/point/PointHistoryController.java
+++ b/src/main/java/com/example/musinssak/api/point/PointHistoryController.java
@@ -1,0 +1,43 @@
+package com.example.musinssak.api.point;
+
+import com.example.musinssak.api.point.dto.PointHistoryListResponse;
+import com.example.musinssak.api.point.facade.PointHistoryFacade;
+import com.example.musinssak.common.util.PeriodFilter;
+import com.example.musinssak.common.web.ApiResponse;
+import com.example.musinssak.infra.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * (적립금) 사용자 적립금 내역 조회
+ * GET /api/users/me/points/histories?period=1m|3m|6m|all
+ */
+@Slf4j
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class PointHistoryController {
+
+    private final PointHistoryFacade pointHistoryFacade;  // 다음 단계에서 구현
+    private final JwtTokenProvider jwtTokenProvider;      // 기존 방식 그대로 사용
+
+    @GetMapping("/me/points/histories")
+    public ApiResponse<PointHistoryListResponse> getMyPointHistories(
+            @RequestHeader("Authorization") String authorizationHeader,
+            @RequestParam(name = "period", defaultValue = "all") String period
+    ) {
+        // 1) 토큰 → userId
+        String token = authorizationHeader.replace("Bearer ", "").trim();
+        Long userId = Long.parseLong(jwtTokenProvider.getSubject(token));
+
+        // 2) 기간 파라미터 파싱 (공통 유틸)
+        PeriodFilter filter = PeriodFilter.from(period);
+
+        // 3) 파사드 위임 (서비스 조립/검증/조회는 파사드/서비스에서 처리)
+        PointHistoryListResponse data = pointHistoryFacade.getPointHistories(userId, filter);
+
+        // 4) 공통 응답 포맷
+        return ApiResponse.success("적립금 내역이 성공적으로 조회되었습니다.", data);
+    }
+}

--- a/src/main/java/com/example/musinssak/api/point/dto/PointHistoryItemResponse.java
+++ b/src/main/java/com/example/musinssak/api/point/dto/PointHistoryItemResponse.java
@@ -1,0 +1,25 @@
+package com.example.musinssak.api.point.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+/**
+ * 적립금 내역 응답 DTO (단일 항목)
+ * - point_histories 테이블의 row를 매핑
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PointHistoryItemResponse {
+    private Long historyId;       // 적립금 내역 ID
+    private String type;          // CHARGE | USE | REFUND | EXPIRE
+    private Integer amount;       // +적립 / -차감
+    private String description;   // 사용자 노출 설명
+    private LocalDate createdAt;  // 발생일 (YYYY-MM-DD)
+    private LocalDate expiredAt;  // 만료일 (null 허용)
+}

--- a/src/main/java/com/example/musinssak/api/point/dto/PointHistoryListResponse.java
+++ b/src/main/java/com/example/musinssak/api/point/dto/PointHistoryListResponse.java
@@ -1,0 +1,21 @@
+package com.example.musinssak.api.point.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 적립금 내역 조회 응답 DTO
+ * - points.total_amount 와 point_histories 목록을 조합
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PointHistoryListResponse {
+    private Integer totalPoint;   // 보유 총 적립금
+    private List<PointHistoryItemResponse> histories; // 내역 리스트
+}

--- a/src/main/java/com/example/musinssak/api/point/facade/PointHistoryFacade.java
+++ b/src/main/java/com/example/musinssak/api/point/facade/PointHistoryFacade.java
@@ -1,0 +1,16 @@
+package com.example.musinssak.api.point.facade;
+
+import com.example.musinssak.api.point.dto.PointHistoryListResponse;
+import com.example.musinssak.common.util.PeriodFilter;
+
+public interface PointHistoryFacade {
+    /**
+     * 사용자 적립금 내역 조회 (총액 + 히스토리)
+     *
+     * @param userId 로그인 사용자 ID
+     * @param filter 기간 필터 (1m | 3m | 6m | all)
+     * @return 총액 및 히스토리 응답 DTO
+     * @throws BusinessException USER_NOT_FOUND, POINT_NOT_FOUND 등
+     */
+    PointHistoryListResponse getPointHistories(Long userId, PeriodFilter filter);
+}

--- a/src/main/java/com/example/musinssak/api/point/facade/PointHistoryFacadeImpl.java
+++ b/src/main/java/com/example/musinssak/api/point/facade/PointHistoryFacadeImpl.java
@@ -1,0 +1,61 @@
+package com.example.musinssak.api.point.facade;
+
+import com.example.musinssak.api.point.dto.PointHistoryItemResponse;
+import com.example.musinssak.api.point.dto.PointHistoryListResponse;
+import com.example.musinssak.common.util.PeriodFilter;
+import com.example.musinssak.domain.point.projection.PointHistoryProjection;
+import com.example.musinssak.domain.point.service.PointQueryService;
+import com.example.musinssak.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 적립금 내역 조회 파사드 (스켈레톤)
+ * - 다음 단계에서 내부 로직을 한 줄씩 채워나간다.
+ */
+@Component
+@RequiredArgsConstructor
+public class PointHistoryFacadeImpl implements PointHistoryFacade {
+
+    private final UserService userService;   // 기존 서비스 인터페이스에 의존
+    private final PointQueryService pointQueryService;
+    private final Clock clock; // 테스트 용이성(시간 주입)
+
+    @Override
+    public PointHistoryListResponse getPointHistories(Long userId, PeriodFilter filter) {
+        // Step 2: 사용자 검증 (없으면 USER_NOT_FOUND 예외 전파)
+        userService.getUserById(userId);
+
+        // Step 3: 기간 → 날짜 범위 계산
+        LocalDate today = LocalDate.now(clock);
+        LocalDate startDate = filter.calcStartDateOrNull(today);
+        // startDate == null 이면 'ALL'(기간 제한 없음) 의미
+
+        // Step 4: 총액 조회 (없으면 POINT_NOT_FOUND)
+        Integer totalPoint = pointQueryService.getTotalPoint(userId);
+
+        // Step 5: 히스토리 조회 (기간/정렬 적용)
+        List<PointHistoryProjection> rows = pointQueryService.findHistories(userId, startDate, today);
+
+        // Step 6: Projection → 응답 DTO 매핑
+        List<PointHistoryItemResponse> items = rows.stream()
+                .map(p -> PointHistoryItemResponse.builder()
+                        .historyId(p.getId())
+                        .type(p.getType().name())                       // Enum이면 .name()
+                        .amount(p.getAmount())
+                        .description(p.getDescription())
+                        .createdAt(p.getCreatedAt().toLocalDate())      // LocalDateTime → LocalDate
+                        .expiredAt(p.getExpiredAt() != null ? p.getExpiredAt().toLocalDate() : null)
+                        .build())
+                .toList();
+
+        return PointHistoryListResponse.builder()
+                .totalPoint(totalPoint)
+                .histories(items)
+                .build();
+    }
+}

--- a/src/main/java/com/example/musinssak/common/config/TimeConfig.java
+++ b/src/main/java/com/example/musinssak/common/config/TimeConfig.java
@@ -1,0 +1,19 @@
+package com.example.musinssak.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Clock;
+import java.time.ZoneId;
+
+@Configuration
+public class TimeConfig {
+
+    @Bean
+    public Clock clock() {
+        // 운영 타임존을 명확히 사용 (예: Asia/Seoul)
+        return Clock.system(ZoneId.of("Asia/Seoul"));
+        // 혹은 기본 시스템 타임존
+        // return Clock.systemDefaultZone();
+    }
+}

--- a/src/main/java/com/example/musinssak/common/exception/ErrorCode.java
+++ b/src/main/java/com/example/musinssak/common/exception/ErrorCode.java
@@ -8,6 +8,9 @@ public enum ErrorCode {
     // 상세 페이지
     PRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "PRODUCT_NOT_FOUND", "해당 상품을 찾을 수 없습니다."),
 
+    // 포인트 공통
+    POINT_NOT_FOUND(HttpStatus.NOT_FOUND, "POINT_NOT_FOUND", "적립금 정보를 찾을 수 없습니다."),
+
     // 비밀번호 변경 관련 (400)
     INVALID_CURRENT_PASSWORD(HttpStatus.BAD_REQUEST, "INVALID_CURRENT_PASSWORD", "현재 비밀번호가 일치하지 않습니다."),
 

--- a/src/main/java/com/example/musinssak/common/util/PeriodFilter.java
+++ b/src/main/java/com/example/musinssak/common/util/PeriodFilter.java
@@ -1,0 +1,40 @@
+package com.example.musinssak.common.util;
+
+import java.time.LocalDate;
+
+/**
+ * 기간 필터 파라미터 유틸
+ *
+ * - 클라이언트가 전달한 "period" 쿼리값(1m, 3m, 6m, all)을 Enum으로 매핑한다.
+ * - ALL 은 기간 제한 없음(null 반환).
+ * - 서비스/파사드 단에서는 calcStartDateOrNull(today) 로 시작일을 계산해 사용한다.
+ *
+ * 사용 예시:
+ *   PeriodFilter filter = PeriodFilter.from("3m");
+ *   LocalDate start = filter.calcStartDateOrNull(LocalDate.now());
+ */
+public enum PeriodFilter {
+    ALL, M1, M3, M6;
+
+    public static PeriodFilter from(String raw) {
+        if (raw == null) return ALL;
+        String v = raw.trim().toLowerCase();
+        return switch (v) {
+            case "1m" -> M1;
+            case "3m" -> M3;
+            case "6m" -> M6;
+            case "all" -> ALL;
+            default -> ALL; // 정의 외 값은 관용적으로 ALL 처리
+        };
+    }
+
+    /** [start, today] 범위를 계산. ALL 은 start=null 의미(필터 없음) */
+    public LocalDate calcStartDateOrNull(LocalDate today) {
+        return switch (this) {
+            case ALL -> null;
+            case M1 -> today.minusMonths(1);
+            case M3 -> today.minusMonths(3);
+            case M6 -> today.minusMonths(6);
+        };
+    }
+}

--- a/src/main/java/com/example/musinssak/domain/point/entity/PointHistory.java
+++ b/src/main/java/com/example/musinssak/domain/point/entity/PointHistory.java
@@ -1,0 +1,45 @@
+package com.example.musinssak.domain.point.entity;
+
+import com.example.musinssak.domain.point.type.PointHistoryType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "point_histories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PointHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** FK → points.id (키만 보관) */
+    @Column(name = "point_id", nullable = false)
+    private Long pointId;
+
+    /** 타입: CHARGE | USE | REFUND | EXPIRE */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", length = 50, nullable = false)
+    private PointHistoryType type;
+
+    /** 금액: 적립(+) / 사용·소멸(-) */
+    @Column(name = "amount", nullable = false)
+    private Integer amount;
+
+    /** 상세 사유 (DDL: TEXT) */
+    @Column(name = "description", columnDefinition = "TEXT", nullable = false)
+    private String description;
+
+    /** 발생 시각 (DDL: DATETIME) */
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    /** 만료 시각 (사용/소멸은 보통 null) */
+    @Column(name = "expired_at")
+    private LocalDateTime expiredAt;
+}

--- a/src/main/java/com/example/musinssak/domain/point/entity/Points.java
+++ b/src/main/java/com/example/musinssak/domain/point/entity/Points.java
@@ -1,0 +1,31 @@
+package com.example.musinssak.domain.point.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "points")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Points {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    /** FK → users.id (키만 보관) */
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    /** 현재 보유 총액 */
+    @Column(name = "total_amount", nullable = false)
+    private Integer totalAmount;
+
+    /** 최신 갱신 시각 (DDL: DATETIME) */
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/musinssak/domain/point/projection/PointHistoryProjection.java
+++ b/src/main/java/com/example/musinssak/domain/point/projection/PointHistoryProjection.java
@@ -1,0 +1,15 @@
+package com.example.musinssak.domain.point.projection;
+
+import com.example.musinssak.domain.point.type.PointHistoryType;
+
+import java.time.LocalDateTime;
+
+/** Projection: DB에서 필요한 컬럼만 얇게 조회 */
+public interface PointHistoryProjection {
+    Long getId();
+    PointHistoryType getType();
+    Integer getAmount();
+    String getDescription();
+    LocalDateTime getCreatedAt(); // DATETIME
+    LocalDateTime getExpiredAt(); // DATETIME (nullable)
+}

--- a/src/main/java/com/example/musinssak/domain/point/repository/PointHistoryRepository.java
+++ b/src/main/java/com/example/musinssak/domain/point/repository/PointHistoryRepository.java
@@ -1,0 +1,55 @@
+package com.example.musinssak.domain.point.repository;
+
+import com.example.musinssak.domain.point.entity.PointHistory;
+import com.example.musinssak.domain.point.projection.PointHistoryProjection;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 적립금 내역 조회용 리포지토리 (Projection 반환)
+ */
+public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
+
+    /** ALL: 기간 제한 없음 (최신순) */
+    @Query("""
+        select 
+            h.id as id,
+            h.type as type,
+            h.amount as amount,
+            h.description as description,
+            h.createdAt as createdAt,
+            h.expiredAt as expiredAt
+        from PointHistory h
+        join com.example.musinssak.domain.point.entity.Points p
+          on h.pointId = p.id
+       where p.userId = :userId
+       order by h.createdAt desc
+    """)
+    List<PointHistoryProjection> findAllByUserIdOrderByCreatedAtDesc(@Param("userId") Long userId);
+
+    /** 기간 지정: [start, end] 포함 (최신순) */
+    @Query("""
+        select 
+            h.id as id,
+            h.type as type,
+            h.amount as amount,
+            h.description as description,
+            h.createdAt as createdAt,
+            h.expiredAt as expiredAt
+        from PointHistory h
+        join com.example.musinssak.domain.point.entity.Points p
+          on h.pointId = p.id
+       where p.userId = :userId
+         and h.createdAt between :start and :end
+       order by h.createdAt desc
+    """)
+    List<PointHistoryProjection> findByUserIdAndCreatedAtBetweenOrderByCreatedAtDesc(
+            @Param("userId") Long userId,
+            @Param("start") LocalDateTime startInclusive,
+            @Param("end") LocalDateTime endInclusive
+    );
+}

--- a/src/main/java/com/example/musinssak/domain/point/repository/PointsRepository.java
+++ b/src/main/java/com/example/musinssak/domain/point/repository/PointsRepository.java
@@ -1,0 +1,17 @@
+package com.example.musinssak.domain.point.repository;
+
+import com.example.musinssak.domain.point.entity.Points;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * 포인트 지갑(points) JPA 리포지토리
+ *
+ * - user_id로 1:1 매핑되는 row를 조회한다.
+ * - 존재하지 않으면 Optional.empty()
+ */
+public interface PointsRepository extends JpaRepository<Points, Long> {
+
+    Optional<Points> findByUserId(Long userId);
+}

--- a/src/main/java/com/example/musinssak/domain/point/service/PointQueryService.java
+++ b/src/main/java/com/example/musinssak/domain/point/service/PointQueryService.java
@@ -1,0 +1,34 @@
+package com.example.musinssak.domain.point.service;
+
+import com.example.musinssak.domain.point.projection.PointHistoryProjection;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 포인트 조회 전용 서비스 포트 (읽기)
+ */
+public interface PointQueryService {
+
+    /**
+     * 사용자 총 적립금(points.total_amount)을 반환한다.
+     * - 해당 사용자의 포인트 지갑(points row)이 없으면 BusinessException(POINT_NOT_FOUND) 발생
+     */
+    Integer getTotalPoint(Long userId);
+
+    /**
+     * 사용자 적립금 내역(point_histories)을 조회한다.
+     * <p>
+     * - startDate가 null이면 전체 조회
+     * - startDate가 있으면 [startDate ~ endDateInclusive] 구간 조회
+     * - created_at DESC(최신순) 정렬
+     *
+     * @param userId 사용자 ID
+     * @param startDate 조회 시작일(포함), null이면 전체 조회
+     * @param endDateInclusive 조회 종료일(포함)
+     * @return 적립금 내역 Projection 목록
+     */
+
+    List<PointHistoryProjection> findHistories(Long userId, LocalDate startDate, LocalDate endDateInclusive);
+
+}

--- a/src/main/java/com/example/musinssak/domain/point/service/PointQueryServiceImpl.java
+++ b/src/main/java/com/example/musinssak/domain/point/service/PointQueryServiceImpl.java
@@ -1,0 +1,51 @@
+package com.example.musinssak.domain.point.service;
+
+import com.example.musinssak.common.exception.BusinessException;
+import com.example.musinssak.common.exception.ErrorCode;
+import com.example.musinssak.domain.point.entity.Points;
+import com.example.musinssak.domain.point.projection.PointHistoryProjection;
+import com.example.musinssak.domain.point.repository.PointHistoryRepository;
+import com.example.musinssak.domain.point.repository.PointsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+/**
+ * 포인트 조회 전용 서비스 구현 (JPA)
+ * - 총액 미존재 시 이 레이어에서 BusinessException(POINT_NOT_FOUND) 처리
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PointQueryServiceImpl implements PointQueryService {
+
+    private final PointsRepository pointsRepository;
+    private final PointHistoryRepository pointHistoryRepository;
+
+    // 사용자 총 적립금(points.total_amount)을 반환한다.
+    @Override
+    public Integer getTotalPoint(Long userId) {
+        // points.user_id 1:1 가정. 없으면 POINT_NOT_FOUND
+        Points wallet = pointsRepository.findByUserId(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.POINT_NOT_FOUND));
+        return wallet.getTotalAmount();
+    }
+
+    // 사용자 적립금 내역(point_histories)을 조회한다.
+    @Override
+    public List<PointHistoryProjection> findHistories(Long userId, LocalDate startDate, LocalDate endDateInclusive) {
+        if (startDate == null) {
+            // ALL: 기간 제한 없음, 최신순
+            return pointHistoryRepository.findAllByUserIdOrderByCreatedAtDesc(userId);
+        }
+        // [start 00:00:00, end 23:59:59.999999999] 포함 범위
+        LocalDateTime start = startDate.atStartOfDay();
+        LocalDateTime end = endDateInclusive.atTime(LocalTime.MAX);
+        return pointHistoryRepository.findByUserIdAndCreatedAtBetweenOrderByCreatedAtDesc(userId, start, end);
+    }
+}

--- a/src/main/java/com/example/musinssak/domain/point/type/PointHistoryType.java
+++ b/src/main/java/com/example/musinssak/domain/point/type/PointHistoryType.java
@@ -1,0 +1,8 @@
+package com.example.musinssak.domain.point.type;
+
+public enum PointHistoryType {
+    CHARGE,
+    USE,
+    REFUND,
+    EXPIRE
+}


### PR DESCRIPTION
[작업한 내용]
- 적립금 내역 조회 API (GET /api/users/me/points/histories) 구현
- domain/point 패키지에 entity, type, projection 추가
- PointQueryService / PointQueryServiceImpl 작성 (조회 전용 서비스)
- PointHistoryFacade / PointHistoryFacadeImpl 작성 (검증 → 조회 → 매핑)
- DTO 작성 (PointHistoryItemResponse, PointHistoryListResponse)
- PeriodFilter 도입 (all / 1m / 3m / 6m) → 시작일 계산
- Repository Projection 기반 조회 (전체/기간별, 최신순 정렬)
- 총액 미존재 시 POINT_NOT_FOUND 예외 처리
- 컨트롤러 작성 (PointHistoryController)
- TimeConfig 추가 (Clock Bean, Asia/Seoul 기준)

[참고사항]
- 사용자 미존재 시 USER_NOT_FOUND 예외 발생
- 포인트 지갑 미존재 시 POINT_NOT_FOUND 예외 발생
- Projection을 Enum(PointHistoryType)으로 매핑하여 타입 안전성 확보
- UX 고려: createdAt DESC 정렬 적용
- 응답 규격: totalPoint + histories 배열 반환