### PR TITLE
Feat: 마이페이지 주문 내역 조회 API 구현

### DIFF
--- a/src/main/java/com/example/musinssak/api/order/OrderController.java
+++ b/src/main/java/com/example/musinssak/api/order/OrderController.java
@@ -1,69 +1,53 @@
-// src/main/java/com/example/musinssak/api/order/OrderController.java
 package com.example.musinssak.api.order;
 
-import com.example.musinssak.api.order.dto.OrderCreateRequest;
-import com.example.musinssak.api.order.dto.OrderCreateResponse;
-import com.example.musinssak.api.order.dto.OrderItemsResponse;
-import com.example.musinssak.api.order.dto.OrderUpdateRequest;
-import com.example.musinssak.api.order.dto.OrderUpdateResponse;
+import com.example.musinssak.api.order.dto.*;
 import com.example.musinssak.application.order.OrderFacade;
 import com.example.musinssak.application.order.OrderPrepareService;
 import com.example.musinssak.application.order.OrderQueryService;
 import com.example.musinssak.application.order.command.CreateOrderCommand;
 import com.example.musinssak.application.order.result.CreateOrderResult;
-import com.example.musinssak.common.web.ApiResponse; // 공통 응답 래퍼임
-import io.swagger.v3.oas.annotations.Operation; // Swagger Operation
+import com.example.musinssak.common.exception.BusinessException;
+import com.example.musinssak.common.exception.ErrorCode;
+import com.example.musinssak.common.web.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
-/**
- * 주문 컨트롤러임
- * - 요청/응답만 처리함
- * - 비즈니스는 파사드/서비스가 함
- */
 @RestController
 @RequestMapping("/api/orders")
 @RequiredArgsConstructor
 public class OrderController {
 
-    private final OrderFacade orderFacade;                 // 주문 생성 파사드
-    private final OrderQueryService orderQueryService;     // 주문 조회 서비스
-    private final OrderPrepareService orderPrepareService; // 주문 준비(정보 갱신/재계산) 서비스
+    private final OrderFacade orderFacade;
+    private final OrderQueryService orderQueryService;
+    private final OrderPrepareService orderPrepareService;
 
-    /**
-     * [POST] /api/orders/create
-     * - 장바구니 선택 상품으로 주문 생성함
-     * - 재고예약/만료시간 등은 파사드가 처리함
-     */
     @Operation(summary = "주문 생성", description = "장바구니 선택 상품으로 주문 생성함")
-    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공") // 이름 충돌 방지 위해 FQN 사용
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
     @PostMapping("/create")
     public ApiResponse<OrderCreateResponse> createOrder(
             @Valid @RequestBody OrderCreateRequest req,
             Authentication authentication
     ) {
-        Long userId = getUserIdOrThrow(authentication); // 유저 id 꺼냄
+        Long userId = getUserIdOrThrow(authentication);
 
-        // 파사드 커맨드 만듦
         CreateOrderCommand command = CreateOrderCommand.builder()
                 .userId(userId)
                 .cartItemIds(req.getCartItemIds())
                 .build();
 
-        // 파사드 호출함
         CreateOrderResult result = orderFacade.create(command);
 
-        // 응답 DTO로 매핑함
         OrderCreateResponse resp = OrderCreateResponse.builder()
-                .orderPk(result.getOrderPk()) //주문 id pk
-                .orderId(result.getOrderNo())                         // 주문번호임
-                .reservationExpiresAt(result.getReservationExpires()) // 만료시각임
-                .totalProductAmount(result.getTotalProductAmount())   // 총 원가 합임
-                .discountAmount(result.getDiscountAmount())           // 총 할인 합임
-                .deliveryFee(result.getDeliveryFee())                 // 배송비임
-                .finalAmount(result.getFinalAmount())                 // 최종금액임
+                .orderPk(result.getOrderPk())
+                .orderId(result.getOrderNo())
+                .reservationExpiresAt(result.getReservationExpires())
+                .totalProductAmount(result.getTotalProductAmount())
+                .discountAmount(result.getDiscountAmount())
+                .deliveryFee(result.getDeliveryFee())
+                .finalAmount(result.getFinalAmount())
                 .orderItems(
                         result.getItems() == null ? null :
                                 result.getItems().stream()
@@ -80,16 +64,9 @@ public class OrderController {
                 )
                 .build();
 
-        // 공통 포맷으로 감싸서 반환함
         return ApiResponse.success(resp);
     }
 
-    /**
-     * [GET] /api/orders/{orderId}/items
-     * - 주문 상품 목록과 합계를 내려줌
-     * - 내 주문만 조회 가능함(소유자 검증함)
-     * - 가격은 주문 시점 스냅샷(oi.price/oi.discountPrice)로 내려줌
-     */
     @Operation(summary = "주문 상품 조회", description = "주문 ID로 상품 목록과 합계를 내려줌(내 주문만 가능함)")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
     @GetMapping("/{orderId}/items")
@@ -97,16 +74,11 @@ public class OrderController {
             @PathVariable Long orderId,
             Authentication authentication
     ) {
-        Long userId = getUserIdOrThrow(authentication); // 유저 id 꺼냄
-        OrderItemsResponse body = orderQueryService.getOrderItems(orderId, userId); // 서비스 호출함
-        return ApiResponse.success(body); // 공통 포맷으로 감싸서 반환함
+        Long userId = getUserIdOrThrow(authentication);
+        OrderItemsResponse body = orderQueryService.getOrderItems(orderId, userId);
+        return ApiResponse.success(body);
     }
 
-    /**
-     * [GET] /api/orders/number/{orderNumber}/items
-     * - 주문번호로 주문 상품 목록과 합계를 내려줌
-     * - 내 주문만 조회 가능함(소유자 검증함)
-     */
     @Operation(summary = "주문번호로 주문 상품 조회", description = "주문번호로 상품 목록과 합계를 내려줌(내 주문만 가능함)")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
     @GetMapping("/number/{orderNumber}/items")
@@ -114,17 +86,11 @@ public class OrderController {
             @PathVariable String orderNumber,
             Authentication authentication
     ) {
-        Long userId = getUserIdOrThrow(authentication); // 유저 id 꺼냄
-        OrderItemsResponse body = orderQueryService.getOrderItemsByNumber(orderNumber, userId); // 서비스 호출함
-        return ApiResponse.success(body); // 공통 포맷으로 감싸서 반환함
+        Long userId = getUserIdOrThrow(authentication);
+        OrderItemsResponse body = orderQueryService.getOrderItemsByNumber(orderNumber, userId);
+        return ApiResponse.success(body);
     }
 
-    /**
-     * [POST] /api/orders/{orderId}/prepare
-     * - 주문 페이지에서 입력한 주문자/배송지 정보를 임시 저장함
-     * - 현재 상품 가격 기준으로 금액을 즉시 재계산해서 돌려줌
-     * - 주문이 CREATED 상태/유효시간 내일 때만 동작함
-     */
     @Operation(summary = "주문 준비(정보 갱신 + 금액 재계산)",
             description = "주문자/배송지 정보를 임시 저장하고 현재 가격 기준으로 결제 예정 금액을 재계산함")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
@@ -139,11 +105,6 @@ public class OrderController {
         return ApiResponse.success(body);
     }
 
-    /**
-     * (선택) [PUT] /api/orders/{orderId}
-     * - 위의 /prepare와 동일 동작을 제공함(호환용)
-     * - 필요 없으면 나중에 제거해도 됨
-     */
     @Operation(summary = "주문 정보 업데이트(호환용)", description = "prepare와 동일한 동작을 PUT으로 제공함")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공")
     @PutMapping("/{orderId}")
@@ -157,12 +118,27 @@ public class OrderController {
         return ApiResponse.success(body);
     }
 
+    @Operation(summary = "내 주문 내역 조회", description = "기간/상태별 필터링, 페이지네이션을 지원합니다.")
+    @GetMapping("/me")
+    public ApiResponse<OrderHistoryResponse> getMyOrderHistory(
+            // [수정] @AuthenticationPrincipal 대신 다른 메소드와 동일하게 Authentication 객체를 받습니다.
+            Authentication authentication,
+            @RequestParam(defaultValue = "3months") String period,
+            @RequestParam(defaultValue = "ALL") String status,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size
+    ) {
+        // [수정] getUserIdOrThrow 헬퍼 메소드를 사용하여 userId를 가져옵니다.
+        Long userId = getUserIdOrThrow(authentication);
+        OrderHistoryResponse body = orderQueryService.getMyOrderHistory(userId, period, status, page, size);
+        return ApiResponse.success("주문 내역이 성공적으로 조회되었습니다.", body);
+    }
+
     /** 인증에서 userId 꺼냄 */
     private Long getUserIdOrThrow(Authentication authentication) {
-        try {
-            return Long.parseLong(authentication.getName()); // 문자열을 숫자로 바꿈
-        } catch (Exception e) {
-            throw new IllegalStateException("인증에서 userId를 찾을 수 없음");
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new BusinessException(ErrorCode.AUTH_REQUIRED);
         }
+        return Long.parseLong(authentication.getPrincipal().toString());
     }
 }

--- a/src/main/java/com/example/musinssak/api/order/dto/OrderHistoryItemDto.java
+++ b/src/main/java/com/example/musinssak/api/order/dto/OrderHistoryItemDto.java
@@ -1,0 +1,16 @@
+package com.example.musinssak.api.order.dto;
+
+import com.example.musinssak.domain.order.entity.OrderStatus;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record OrderHistoryItemDto(
+        String orderDate,
+        String orderNumber,
+        List<OrderItemDto> items,
+        int totalAmount,
+        OrderStatus orderStatus
+) {
+}

--- a/src/main/java/com/example/musinssak/api/order/dto/OrderHistoryResponse.java
+++ b/src/main/java/com/example/musinssak/api/order/dto/OrderHistoryResponse.java
@@ -1,0 +1,12 @@
+package com.example.musinssak.api.order.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record OrderHistoryResponse(
+        List<OrderHistoryItemDto> orders,
+        PaginationDto pagination
+) {
+}

--- a/src/main/java/com/example/musinssak/api/order/dto/OrderItemDto.java
+++ b/src/main/java/com/example/musinssak/api/order/dto/OrderItemDto.java
@@ -1,0 +1,11 @@
+package com.example.musinssak.api.order.dto;
+
+import lombok.Builder;
+
+@Builder
+public record OrderItemDto(
+        String name,
+        String option,
+        String thumbnailUrl
+) {
+}

--- a/src/main/java/com/example/musinssak/api/order/dto/PaginationDto.java
+++ b/src/main/java/com/example/musinssak/api/order/dto/PaginationDto.java
@@ -1,0 +1,12 @@
+package com.example.musinssak.api.order.dto;
+
+import lombok.Builder;
+
+@Builder
+public record PaginationDto(
+        int page,
+        int size,
+        long totalElements,
+        int totalPages
+) {
+}

--- a/src/main/java/com/example/musinssak/application/order/OrderQueryService.java
+++ b/src/main/java/com/example/musinssak/application/order/OrderQueryService.java
@@ -1,13 +1,12 @@
-// src/main/java/com/example/musinssak/application/order/OrderQueryService.java
 package com.example.musinssak.application.order;
 
+import com.example.musinssak.api.order.dto.OrderHistoryResponse; // [추가]
 import com.example.musinssak.api.order.dto.OrderItemsResponse;
 
-/** 주문 조회 유스케이스임(읽기 전용임) */
 public interface OrderQueryService {
-    /** 내 주문 아이템 목록/합계 내려줌 */
     OrderItemsResponse getOrderItems(Long orderId, Long userId);
-
-    /** 주문번호로 내 주문 아이템 목록/합계 내려줌 */
     OrderItemsResponse getOrderItemsByNumber(String orderNumber, Long userId);
+
+    // [추가] 주문 내역 조회 메소드
+    OrderHistoryResponse getMyOrderHistory(Long userId, String period, String status, int page, int size);
 }

--- a/src/main/java/com/example/musinssak/application/order/OrderQueryServiceImpl.java
+++ b/src/main/java/com/example/musinssak/application/order/OrderQueryServiceImpl.java
@@ -1,7 +1,6 @@
-// src/main/java/com/example/musinssak/application/order/OrderQueryServiceImpl.java
 package com.example.musinssak.application.order;
 
-import com.example.musinssak.api.order.dto.OrderItemsResponse;
+import com.example.musinssak.api.order.dto.*;
 import com.example.musinssak.common.exception.BusinessException;
 import com.example.musinssak.common.exception.ErrorCode;
 import com.example.musinssak.domain.order.entity.OrderStatus;
@@ -10,11 +9,16 @@ import com.example.musinssak.domain.order.repository.OrderItemRepository;
 import com.example.musinssak.domain.order.repository.OrdersRepository;
 import com.example.musinssak.domain.order.repository.view.OrderItemRow;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /** 주문 조회 구현체임 */
 @Service
@@ -24,26 +28,23 @@ public class OrderQueryServiceImpl implements OrderQueryService {
 
     private final OrdersRepository ordersRepository;
     private final OrderItemRepository orderItemRepository;
-    private final OrderStatusUpdater orderStatusUpdater; // ★ 추가
+    private final OrderStatusUpdater orderStatusUpdater;
 
     @Override
     public OrderItemsResponse getOrderItems(Long orderId, Long userId) {
-        // 1) 내 주문인지 확인
+        // ... (이 메소드는 수정 없음)
         Orders order = ordersRepository.findByIdAndUserId(orderId, userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.FORBIDDEN));
 
-        // 2) 만료 즉시 반영(읽기 트랜잭션이지만 내부에서 REQUIRES_NEW로 상태만 커밋)
         if (order.getStatus() == OrderStatus.CREATED
                 && order.getExpiredAt() != null
                 && order.getExpiredAt().isBefore(LocalDateTime.now())) {
-            orderStatusUpdater.markPaymentExpiredNow(order.getId()); // DB에 바로 반영
+            orderStatusUpdater.markPaymentExpiredNow(order.getId());
             throw new BusinessException(ErrorCode.ORDER_TIME_EXPIRED);
         }
 
-        // 3) 아이템 조인 조회
         List<OrderItemRow> rows = orderItemRepository.findRowsByOrderIdAndUserId(orderId, userId);
 
-        // 4) 응답
         return OrderItemsResponse.builder()
                 .orderPk(order.getId())
                 .orderId(order.getId())
@@ -71,22 +72,19 @@ public class OrderQueryServiceImpl implements OrderQueryService {
 
     @Override
     public OrderItemsResponse getOrderItemsByNumber(String orderNumber, Long userId) {
-        // 1) 내 주문인지 확인
+        // ... (이 메소드는 수정 없음)
         Orders order = ordersRepository.findByOrderNumberAndUserId(orderNumber, userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.FORBIDDEN));
 
-        // 2) 만료 즉시 반영(읽기 트랜잭션이지만 내부에서 REQUIRES_NEW로 상태만 커밋)
         if (order.getStatus() == OrderStatus.CREATED
                 && order.getExpiredAt() != null
                 && order.getExpiredAt().isBefore(LocalDateTime.now())) {
-            orderStatusUpdater.markPaymentExpiredNow(order.getId()); // DB에 바로 반영
+            orderStatusUpdater.markPaymentExpiredNow(order.getId());
             throw new BusinessException(ErrorCode.ORDER_TIME_EXPIRED);
         }
 
-        // 3) 아이템 조인 조회
         List<OrderItemRow> rows = orderItemRepository.findRowsByOrderIdAndUserId(order.getId(), userId);
 
-        // 4) 응답
         return OrderItemsResponse.builder()
                 .orderPk(order.getId())
                 .orderId(order.getId())
@@ -110,5 +108,60 @@ public class OrderQueryServiceImpl implements OrderQueryService {
                                 .build()
                 ).toList())
                 .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public OrderHistoryResponse getMyOrderHistory(Long userId, String period, String status, int page, int size) {
+        LocalDateTime startDate = switch (period) {
+            case "1month" -> LocalDateTime.now().minusMonths(1);
+            case "3months" -> LocalDateTime.now().minusMonths(3);
+            case "6months" -> LocalDateTime.now().minusMonths(6);
+            default -> null;
+        };
+
+        // -- [이 switch 구문을 수정했습니다] --
+        List<OrderStatus> statuses = switch (status) {
+            // 'ORDERED'는 현재 'PAID' 상태만 보도록 단순화했습니다.
+            case "ORDERED" -> List.of(OrderStatus.PAID);
+            // 'CANCELLED'는 enum에 존재하므로 그대로 둡니다.
+            case "CANCELLED" -> List.of(OrderStatus.CANCELLED);
+            // 'RETURNED'는 enum에 없으므로, 빈 목록을 반환하도록 처리합니다.
+            case "RETURNED" -> List.of();
+            // 'ALL' 또는 그 외의 경우는 모든 상태를 조회하므로 빈 목록을 전달합니다.
+            default -> List.of();
+        };
+
+        Pageable pageable = PageRequest.of(page, size);
+        Page<Orders> orderPage = ordersRepository.findMyOrderHistory(userId, startDate, statuses, pageable);
+
+        List<OrderHistoryItemDto> orderDtos = orderPage.getContent().stream()
+                .map(order -> {
+                    List<OrderItemDto> itemDtos = order.getItems().stream()
+                            .map(item -> OrderItemDto.builder()
+                                    .name(item.getProduct().getName())
+                                    .option(item.getProductOptionId() + " / 수량: " + item.getQuantity() + "개")
+                                    .thumbnailUrl(item.getProduct().getThumbnailImageUrl())
+                                    .build())
+                            .collect(Collectors.toList());
+
+                    return OrderHistoryItemDto.builder()
+                            .orderDate(order.getCreatedAt().toLocalDate().format(DateTimeFormatter.ISO_LOCAL_DATE))
+                            .orderNumber(order.getOrderNumber())
+                            .items(itemDtos)
+                            .totalAmount(order.getFinalPaymentPrice())
+                            .orderStatus(order.getStatus())
+                            .build();
+                })
+                .collect(Collectors.toList());
+
+        PaginationDto paginationDto = PaginationDto.builder()
+                .page(orderPage.getNumber())
+                .size(orderPage.getSize())
+                .totalElements(orderPage.getTotalElements())
+                .totalPages(orderPage.getTotalPages())
+                .build();
+
+        return new OrderHistoryResponse(orderDtos, paginationDto);
     }
 }

--- a/src/main/java/com/example/musinssak/domain/order/repository/OrdersRepository.java
+++ b/src/main/java/com/example/musinssak/domain/order/repository/OrdersRepository.java
@@ -10,8 +10,10 @@ import org.springframework.data.jpa.repository.Query;
 import java.time.LocalDateTime;
 import java.util.List; // [추가] List를 import 합니다.
 import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
-public interface OrdersRepository extends JpaRepository<Orders, Long> {
+public interface OrdersRepository extends JpaRepository<Orders, Long>, OrdersRepositoryCustom {
 
     /** 주문번호로 단건 찾음 */
     Optional<Orders> findByOrderNumber(String orderNumber);

--- a/src/main/java/com/example/musinssak/domain/order/repository/OrdersRepositoryCustom.java
+++ b/src/main/java/com/example/musinssak/domain/order/repository/OrdersRepositoryCustom.java
@@ -1,0 +1,14 @@
+package com.example.musinssak.domain.order.repository;
+
+import com.example.musinssak.domain.order.entity.Orders;
+// [추가] OrderStatus를 import 해주세요!
+import com.example.musinssak.domain.order.entity.OrderStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface OrdersRepositoryCustom {
+    Page<Orders> findMyOrderHistory(Long userId, LocalDateTime startDate, List<OrderStatus> statuses, Pageable pageable);
+}

--- a/src/main/java/com/example/musinssak/domain/order/repository/OrdersRepositoryCustomImpl.java
+++ b/src/main/java/com/example/musinssak/domain/order/repository/OrdersRepositoryCustomImpl.java
@@ -1,0 +1,56 @@
+package com.example.musinssak.domain.order.repository;
+
+import com.example.musinssak.domain.order.entity.Orders;
+import com.example.musinssak.domain.order.entity.OrderStatus;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.example.musinssak.domain.order.entity.QOrders.orders;
+
+@RequiredArgsConstructor
+public class OrdersRepositoryCustomImpl implements OrdersRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<Orders> findMyOrderHistory(Long userId, LocalDateTime startDate, List<OrderStatus> statuses, Pageable pageable) {
+        List<Orders> content = queryFactory
+                .selectFrom(orders)
+                .where(
+                        orders.userId.eq(userId),
+                        createdAtGoe(startDate),
+                        statusIn(statuses)
+                )
+                .orderBy(orders.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = queryFactory
+                .select(orders.count())
+                .from(orders)
+                .where(
+                        orders.userId.eq(userId),
+                        createdAtGoe(startDate),
+                        statusIn(statuses)
+                )
+                .fetchOne();
+
+        return new PageImpl<>(content, pageable, total != null ? total : 0L);
+    }
+
+    private BooleanExpression createdAtGoe(LocalDateTime startDate) {
+        return startDate != null ? orders.createdAt.goe(startDate) : null;
+    }
+
+    private BooleanExpression statusIn(List<OrderStatus> statuses) {
+        return statuses != null && !statuses.isEmpty() ? orders.status.in(statuses) : null;
+    }
+}


### PR DESCRIPTION
[작업한 내용]

- 마이페이지의 주문 내역을 조회하는 API (GET /api/orders/me)를 구현
- 기간별 필터링
- 주문 상태별 필터링
- 페이지네이션 지원

[참고사항]

- API 명세에 따라 PAID, PREPARING_DELIVERY, DELIVERING, DELIVERY_COMPLETED 상태를 모두 포함하도록 처리했습니다.